### PR TITLE
don't show article list unless logged in

### DIFF
--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,4 +1,4 @@
-- if current_user
+- if user_signed_in?
   .main
     %h1 Articles
     .search-bar


### PR DESCRIPTION
I have 2 reasons for this:

1) Some of our article titles border on trade secrets- things like our hosting providers, marketing promotions, and fixes to our frequent problems are things that we don't need to offer our competitors for free or show to the general public.  If we want to be transparent about a particular thing, we can write a blog post. 

2) It's really confusing to think you're see all the articles and think you're logged in when you're not.
