### PR TITLE
Refactors Article statuses and their tests

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -105,7 +105,7 @@ class Article < ActiveRecord::Base
   # an article is rotten when it has been manually marked as rotten and
   # the rotted_at timestamp has been set (it defaults to nil)
   def rotten?
-    self.rotted_at != nil
+    rotted_at.present?
   end
 
   def refresh!

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -35,7 +35,7 @@ class Article < ActiveRecord::Base
   scope :archived, -> { where.not(archived_at: nil) }
   scope :current, -> { where(archived_at: nil).order("rotted_at DESC") }
   scope :fresh, -> do
-    where("updated_at >= ?", FRESHNESS_LIMIT.ago.beginning_of_day).
+    where("updated_at >= ?", FRESHNESS_LIMIT.ago).
       where(archived_at: nil).
       where(rotted_at: nil)
   end
@@ -43,7 +43,7 @@ class Article < ActiveRecord::Base
   scope :popular, -> { order("endorsements_count DESC, subscriptions_count DESC, visits DESC") }
   scope :rotten, -> { where("rotted_at IS NOT NULL") }
   scope :stale, -> do
-      where("updated_at < ?", STALENESS_LIMIT.ago.beginning_of_day)
+    where("updated_at < ?", STALENESS_LIMIT.ago)
   end
 
   def self.count_visit(article_instance)
@@ -91,7 +91,7 @@ class Article < ActiveRecord::Base
   # an article is fresh when it has been created or updated 7 days ago
   # or more recently
   def fresh?
-    self.updated_at >= FRESHNESS_LIMIT.ago.beginning_of_day &&
+    self.updated_at >= FRESHNESS_LIMIT.ago &&
     self.archived_at == nil &&
     self.rotted_at == nil
   end
@@ -99,7 +99,7 @@ class Article < ActiveRecord::Base
   # an article is stale when it has been created over 4 months ago
   # and has never been updated since
   def stale?
-    self.updated_at < STALENESS_LIMIT.ago.beginning_of_day
+    self.updated_at < STALENESS_LIMIT.ago
   end
 
   # an article is rotten when it has been manually marked as rotten and

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -88,20 +88,14 @@ class Article < ActiveRecord::Base
     self.editor.present?
   end
 
-  # an article is fresh when it has been created or updated 7 days ago
-  # or more recently
   def fresh?
     !archived? && !rotten? && updated_at >= FRESHNESS_LIMIT.ago
   end
 
-  # an article is stale when it has been created over 4 months ago
-  # and has never been updated since
   def stale?
     updated_at < STALENESS_LIMIT.ago
   end
 
-  # an article is rotten when it has been manually marked as rotten and
-  # the rotted_at timestamp has been set (it defaults to nil)
   def rotten?
     rotted_at.present?
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -97,7 +97,7 @@ class Article < ActiveRecord::Base
   # an article is stale when it has been created over 4 months ago
   # and has never been updated since
   def stale?
-    self.updated_at < STALENESS_LIMIT.ago
+    updated_at < STALENESS_LIMIT.ago
   end
 
   # an article is rotten when it has been manually marked as rotten and

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -77,7 +77,7 @@ class Article < ActiveRecord::Base
   end
 
   def archived?
-    !self.archived_at.nil?
+    archived_at.present?
   end
 
   def different_editor?

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -91,9 +91,7 @@ class Article < ActiveRecord::Base
   # an article is fresh when it has been created or updated 7 days ago
   # or more recently
   def fresh?
-    self.updated_at >= FRESHNESS_LIMIT.ago &&
-    self.archived_at == nil &&
-    self.rotted_at == nil
+    !archived? && !rotten? && updated_at >= FRESHNESS_LIMIT.ago
   end
 
   # an article is stale when it has been created over 4 months ago

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -196,15 +196,16 @@ describe Article do
   end
 
   describe "#stale?" do
-    let(:fresh_article) { create(:article) }
-    let(:stale_article) { create(:article, :stale) }
+    subject { described_class.new }
 
-    it "is true for stale articles" do
-      expect(stale_article.stale?).to be_truthy
+    context 'when time since updated exceeds the STALENESS_LIMIT' do
+      before { subject.updated_at = (described_class::STALENESS_LIMIT + 1.minute).ago }
+      specify { expect(subject.stale?).to be true }
     end
 
-    it "is false for fresh articles" do
-      expect(fresh_article.stale?).to be_falsey
+    context 'when time since updated is within the STALENESS_LIMIT' do
+      before { subject.updated_at = (described_class::STALENESS_LIMIT - 1.minute).ago }
+      specify { expect(subject.stale?).to be false }
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -364,21 +364,16 @@ describe Article do
     end
   end
 
-  describe "#rotten?" do
-    let(:fresh_article) { create(:article, :fresh) }
-    let(:stale_article) { create(:article, :stale) }
-    let(:rotten_article) { create(:article, :rotten) }
+  describe '#rotten?' do
+    subject { described_class.new }
 
-    it "returns false for a fresh article" do
-      expect(fresh_article.rotten?).to be_falsey
+    context 'when rotted_at is not set' do
+      specify { expect(subject.rotten?).to be false }
     end
 
-    it "returns false for a stale article" do
-      expect(stale_article.rotten?).to be_falsey
-    end
-
-    it "returns true for a rotten article" do
-      expect(rotten_article.rotten?).to be_truthy
+    context 'when rotted_at is set' do
+      before { subject.rotted_at = Time.current }
+      specify { expect(subject.rotten?).to be true }
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -154,23 +154,23 @@ describe Article do
 
     context 'when it is archived' do
       before { subject.archived_at = Time.current }
-      specify { expect(subject.fresh?).to be false }
+      it { should_not be_fresh }
     end
 
     context 'when it is rotten' do
       before { subject.rotted_at = Time.current }
-      specify { expect(subject.fresh?).to be false }
+      it { should_not be_fresh }
     end
 
     context 'when it is neither archived nor rotten' do
       context 'and when time since updated exceeds the FRESHNESS_LIMIT' do
         before { subject.updated_at = (described_class::FRESHNESS_LIMIT + 1.minute).ago }
-        specify { expect(subject.fresh?).to be false }
+        it { should_not be_fresh }
       end
 
       context 'and when time since updated is within the FRESHNESS_LIMIT' do
         before { subject.updated_at = (described_class::FRESHNESS_LIMIT - 1.minute).ago }
-        specify { expect(subject.fresh?).to be true }
+        it { should be_fresh }
       end
     end
   end
@@ -200,12 +200,12 @@ describe Article do
 
     context 'when time since updated exceeds the STALENESS_LIMIT' do
       before { subject.updated_at = (described_class::STALENESS_LIMIT + 1.minute).ago }
-      specify { expect(subject.stale?).to be true }
+      it { should be_stale }
     end
 
     context 'when time since updated is within the STALENESS_LIMIT' do
       before { subject.updated_at = (described_class::STALENESS_LIMIT - 1.minute).ago }
-      specify { expect(subject.stale?).to be false }
+      it { should_not be_stale }
     end
   end
 
@@ -382,12 +382,12 @@ describe Article do
     subject { described_class.new }
 
     context 'when rotted_at is not set' do
-      specify { expect(subject.rotten?).to be false }
+      it { should_not be_rotten }
     end
 
     context 'when rotted_at is set' do
       before { subject.rotted_at = Time.current }
-      specify { expect(subject.rotten?).to be true }
+      it { should be_rotten }
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -267,6 +267,19 @@ describe Article do
     end
   end
 
+  describe '#archived?' do
+    subject { described_class.new }
+
+    context 'when archived_at is not set' do
+      specify { expect(subject.archived?).to be false }
+    end
+
+    context 'when archived_at is set' do
+      before { subject.archived_at = Time.current }
+      specify { expect(subject.archived?).to be true }
+    end
+  end
+
   describe "#fresh?" do
     subject(:fresh?) { article.fresh? }
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -294,34 +294,6 @@ describe Article do
     end
   end
 
-  describe "#fresh?" do
-    subject(:fresh?) { article.fresh? }
-
-    context 'with a fresh article' do
-      let(:article) { create(:article, :fresh) }
-
-      it "returns true" do
-        expect(fresh?).to be_truthy
-      end
-    end
-
-    context 'with a stale article' do
-      let(:article) { create(:article, :stale) }
-
-      it "returns false" do
-        expect(fresh?).to be_falsey
-      end
-    end
-
-    context 'with a rotten article' do
-      let(:article) { create(:article, :rotten) }
-
-      it "returns false" do
-        expect(fresh?).to be_falsey
-      end
-    end
-  end
-
   describe "#refresh!" do
     subject(:refresh!) { article.refresh! }
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -149,16 +149,29 @@ describe Article do
     end
   end
 
-  describe "#fresh?" do
-    let(:fresh_article) { create(:article) }
-    let(:stale_article) { create(:article, :stale) }
+  describe '#fresh?' do
+    subject { described_class.new }
 
-    it "is true for fresh articles" do
-      expect(fresh_article.fresh?).to be_truthy
+    context 'when it is archived' do
+      before { subject.archived_at = Time.current }
+      specify { expect(subject.fresh?).to be false }
     end
 
-    it "is false for stale articles" do
-      expect(stale_article.fresh?).to be_falsey
+    context 'when it is rotten' do
+      before { subject.rotted_at = Time.current }
+      specify { expect(subject.fresh?).to be false }
+    end
+
+    context 'when it is neither archived nor rotten' do
+      context 'and when time since updated exceeds the FRESHNESS_LIMIT' do
+        before { subject.updated_at = (described_class::FRESHNESS_LIMIT + 1.minute).ago }
+        specify { expect(subject.fresh?).to be false }
+      end
+
+      context 'and when time since updated is within the FRESHNESS_LIMIT' do
+        before { subject.updated_at = (described_class::FRESHNESS_LIMIT - 1.minute).ago }
+        specify { expect(subject.fresh?).to be true }
+      end
     end
   end
 


### PR DESCRIPTION
Heard about this project on Ruby5. Thanks for open-sourcing it, @olivierlacan! 
I noticed some not-so-truthful comments in `Article` so I thought I'd contribute...

**Changes:**
- `beginning_of_day` consideration removed from `.fresh` and `.stale` scopes. This did not seem to break any tests and removing them eliminates complexity around time and makes it easier to test.
- specs for `#archive?`, `#fresh?`,  `#stale?`, and `#rotten?` were rewritten to be more thorough and to remove dependency on persistence and factories.
- implementation for `#archive?`, `#fresh?`,  `#stale?`, and `#rotten?` refactored for readability.
- rotten or rot-prone comments were removed in favor of more readable code.

btw, tests on `master` were breaking when I pulled, but all green tests are still green locally after changes.

Hope this helps!