### PR TITLE
Replace ad-hoc slugs with FriendlyId

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'responders','~> 2.0'
 gem 'skylight'
 gem 'bugsnag'
 gem 'slack-notifier'
+gem 'friendly_id'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
       json (~> 1.4)
       listen (>= 1.0, < 3.0)
       thor (~> 0.14)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     globalid (0.3.3)
       activesupport (>= 4.1.0)
     haml (4.0.6)
@@ -337,6 +339,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.2.1)
   faker
   fontcustom
+  friendly_id
   haml-rails
   mandrill_mailer
   omniauth

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20150416104151_create_friendly_id_slugs.rb
+++ b/db/migrate/20150416104151_create_friendly_id_slugs.rb
@@ -1,0 +1,25 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  class MigrationArticle < ActiveRecord::Base
+    self.table_name = :articles
+  end
+
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+
+    # This will generate a FriendlyId slug for all existing cached slugs in
+    # order to not create 404s when/if article titles are ever changed.
+    say_with_time "Migrating existing slugs to FriendlyId" do
+      MigrationArticle.all.each(&:save!)
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -214,6 +214,39 @@ ALTER SEQUENCE delayed_jobs_id_seq OWNED BY delayed_jobs.id;
 
 
 --
+-- Name: friendly_id_slugs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE friendly_id_slugs (
+    id integer NOT NULL,
+    slug character varying NOT NULL,
+    sluggable_id integer NOT NULL,
+    sluggable_type character varying(50),
+    scope character varying,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: friendly_id_slugs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE friendly_id_slugs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: friendly_id_slugs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE friendly_id_slugs_id_seq OWNED BY friendly_id_slugs.id;
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -326,6 +359,13 @@ ALTER TABLE ONLY delayed_jobs ALTER COLUMN id SET DEFAULT nextval('delayed_jobs_
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY friendly_id_slugs ALTER COLUMN id SET DEFAULT nextval('friendly_id_slugs_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
 
 
@@ -366,6 +406,14 @@ ALTER TABLE ONLY articles
 
 ALTER TABLE ONLY delayed_jobs
     ADD CONSTRAINT delayed_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: friendly_id_slugs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY friendly_id_slugs
+    ADD CONSTRAINT friendly_id_slugs_pkey PRIMARY KEY (id);
 
 
 --
@@ -424,6 +472,34 @@ CREATE UNIQUE INDEX index_articles_on_slug ON articles USING btree (slug);
 --
 
 CREATE INDEX index_articles_tags_on_article_id_and_tag_id ON articles_tags USING btree (article_id, tag_id);
+
+
+--
+-- Name: index_friendly_id_slugs_on_slug_and_sluggable_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type ON friendly_id_slugs USING btree (slug, sluggable_type);
+
+
+--
+-- Name: index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope ON friendly_id_slugs USING btree (slug, sluggable_type, scope);
+
+
+--
+-- Name: index_friendly_id_slugs_on_sluggable_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_friendly_id_slugs_on_sluggable_id ON friendly_id_slugs USING btree (sluggable_id);
+
+
+--
+-- Name: index_friendly_id_slugs_on_sluggable_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_friendly_id_slugs_on_sluggable_type ON friendly_id_slugs USING btree (sluggable_type);
 
 
 --
@@ -501,4 +577,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150328040718');
 INSERT INTO schema_migrations (version) VALUES ('20150328040918');
 
 INSERT INTO schema_migrations (version) VALUES ('20150328074815');
+
+INSERT INTO schema_migrations (version) VALUES ('20150416104151');
 


### PR DESCRIPTION
Two related changes of note:
- in ArticlesController, the new respond_with_article_or_redirect method
will redirect to the article_path based on the current slug in case the request
asked for an old slug and return a 301 moved permanently status code
- in the migration, we call save! on all articles in order to trigger the
creation of a FriendlyId

Addresses #127 