### PR TITLE
dotenv should not be in the development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'skylight'
 gem 'bugsnag'
 gem 'slack-notifier'
 gem 'friendly_id'
+gem 'dotenv-rails'
 
 group :development do
   gem 'better_errors'
@@ -41,7 +42,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'dotenv-rails'
   gem 'rspec-rails', '~> 3.2.0'
   gem 'factory_girl_rails', '~> 4.2.1'
   gem 'faker'


### PR DESCRIPTION
The dotenv gem is required in production and should be in the correct place int he Gemfile