### PR TITLE
Redirect to articles#new on 404

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,10 @@
 class ArticlesController < ApplicationController
-  before_filter :find_article_by_params, only: [:show, :edit, :update, :destroy]
+  before_filter :find_article_by_params, only: [
+    :show,
+    :edit,
+    :update,
+    :destroy
+  ]
   before_filter :decorate_article, only: [
     :show,
     :edit,
@@ -141,7 +146,11 @@ class ArticlesController < ApplicationController
   end
 
   def find_article_by_params
-    @article ||= Article.friendly.where(slug: params[:id]).first
+    @article ||= begin
+      Article.friendly.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      Article.friendly.none
+    end
   end
   helper_method :article
 
@@ -149,6 +158,7 @@ class ArticlesController < ApplicationController
     if @article.present?
       respond_with_article_or_redirect
     else
+      flash[:notice] = "Since this article doesn't exist, it would be super nice if you wrote it. :-)"
       redirect_to new_article_path(title: params[:id].titleize)
     end
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -16,8 +16,8 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article.count_visit
-    respond_with_article_or_redirect
+    respond_with_article_or_redirect_or_new
+    @article.count_visit if @article.present?
   end
 
   def new
@@ -141,14 +141,23 @@ class ArticlesController < ApplicationController
   end
 
   def find_article_by_params
-    @article ||= Article.friendly.find(params[:id])
+    @article ||= Article.friendly.where(slug: params[:id]).first
   end
   helper_method :article
+
+  def respond_with_article_or_redirect_or_new
+    if @article.present?
+      respond_with_article_or_redirect
+    else
+      redirect_to new_article_path(title: params[:id].titleize)
+    end
+  end
 
   def respond_with_article_or_redirect
     # If an old id or a numeric id was used to find the record, then
     # the request path will not match the post_path, and we should do
     # a 301 redirect that uses the current friendly id.
+
     if request.path != article_path(@article)
       return redirect_to @article, status: :moved_permanently
     else


### PR DESCRIPTION
Grab the slug and titleize it to extract a potential title and
encourage people to write articles that don't already exists.

This makes sense now that it's unlikely that 404 will happen due to
oudated slugs since we retain slug history and redirection of old
slugs to new ones through FriendlyId.