### PR TITLE
Fix wrong addon name/plan combination

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
   "addons": [
     "scheduler:standard",
     "heroku-postgresql:hobby-dev",
-    "logentries:tryit"
+    "logentries"
   ],
   "env": {
     "ORIENTATION_LOGO": "/assets/default_logo.svg",


### PR DESCRIPTION
The current app.json definition is not correct and the app creation fails on Heroku