### PR TITLE
Teams

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,9 @@
+class TeamsController < ApplicationController
+  def index
+
+  end
+
+  def show
+    @team = Team.friendly.find(params[:id])
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,10 @@
+class Team < ActiveRecord::Base
+  extend FriendlyId
+
+  has_many :users
+  has_many :articles, through: :users, source: :articles
+  has_many :subscribed_articles, through: :users, source: :subscribed_articles
+  has_many :edits, through: :users, source: :edits
+
+  friendly_id :name, use: [:slugged, :history]
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   belongs_to :article
+  belongs_to :team
   has_many :articles, foreign_key: "author_id"
   has_many :subscriptions, class_name: "ArticleSubscription"
   has_many :subscribed_articles, through: :subscriptions, source: :article

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -1,0 +1,67 @@
+%section.row
+  .cell.well.well--l
+    .g
+      .g-b.g-b--m--1of3
+
+        .card.card--b.tac.mbs.has-card-section
+          %h1.tsl
+            = @team.name
+
+          - if current_user == @team
+            .form
+              = simple_form_for @team.source, url: author_path( @team ), method: :patch do | f |
+
+                %fieldset.form-field
+                  - if @team == current_user
+                    = f.text_area :shtick, required: false, placeholder: 'What do you do?',
+                     class: 'form-input form-input--textarea'
+                  - else
+                    = f.text_area :shtick, required: false, placeholder: 'What do they do?',
+                     class: 'form-input form-input--textarea'
+
+                = f.submit 'Update', class: 'btn btn--b'
+          - else
+            %p.mbxs= @team.shtick
+
+          .card-section.card-section--row
+            %h2.mbs Contributions
+            %p.mbxs.tss Created #{ pluralize( @team.articles.count, 'article' ) }
+            %p.mbf.tss Edited #{ pluralize( @team.edits.count, 'article' ) }
+
+        .tac.mbm
+          = link_to 'Toggle Status', author_toggle_status_path( @team ), method: :put
+
+      .g-b.g-b--m--2of3
+
+        %h2.mbs Created Articles
+        - if @team.articles.count > 0
+          - # TODO: Apply signal classes unique to Article decorator
+          %ul.list.list--xs.mbl
+            - @team.articles.each do | article |
+              %li.card.list-item.article{ class: ( 'has-article-footer' unless article.tags.empty? ) }
+                = link_to article.title, article, class: 'article-title'
+        - else
+          - if current_user == @team
+            %p
+              Hey, everyone has to start somewhere.
+              = link_to 'Create an article', new_article_url, class: 'dib'
+          - else
+            %p #{ @team.name } hasn't created any articles yet.
+
+        %h2.mbs Edited Articles
+        - if @team.edits.count > 0
+          %ul.list.list--xs.mbl
+            - @team.edits.each do | article |
+              %li.card.list-item.article{ class: ( 'has-article-footer' unless article.tags.empty? ) }
+                = link_to article.title, article, class: 'article-title'
+        - else
+          %p #{ @team.name } hasn't edited any articles yet.
+
+        %h2.mbs Article Subscriptions
+        - if @team.subscribed_articles.count > 0
+          %ul.list.list--xs
+            - @team.subscribed_articles.each do | article |
+              %li.card.list-item.article{ class: ( 'has-article-footer' unless article.tags.empty? ) }
+                = link_to article.title, article, class: 'article-title'
+        - else
+          %p #{ @team.name } isn't subscribed to any articles yet.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   resources :guides, only: [:show, :index]
   resources :subscriptions, only: :index
   resources :endorsements, only: :index
+  resources :teams
 
   # this has to be the last route because we're catching slugs at the root path
   resources :articles, path: "", only: :show

--- a/db/migrate/20150714075016_create_teams.rb
+++ b/db/migrate/20150714075016_create_teams.rb
@@ -1,0 +1,11 @@
+class CreateTeams < ActiveRecord::Migration
+  def change
+    create_table :teams do |t|
+      t.string :name
+      t.string :shtick
+      t.string :slug
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150714075047_add_team_id_to_users.rb
+++ b/db/migrate/20150714075047_add_team_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddTeamIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :team_id, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -289,6 +289,39 @@ ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
+-- Name: teams; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE teams (
+    id integer NOT NULL,
+    name character varying,
+    shtick character varying,
+    slug character varying,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: teams_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE teams_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: teams_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE teams_id_seq OWNED BY teams.id;
+
+
+--
 -- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -304,7 +337,7 @@ CREATE TABLE users (
     avatar character varying(255),
     active boolean DEFAULT true,
     shtick text,
-    articles_count integer DEFAULT 0 NOT NULL
+    team_id integer
 );
 
 
@@ -325,6 +358,41 @@ CREATE SEQUENCE users_id_seq
 --
 
 ALTER SEQUENCE users_id_seq OWNED BY users.id;
+
+
+--
+-- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE versions (
+    id integer NOT NULL,
+    item_type character varying(255) NOT NULL,
+    item_id integer NOT NULL,
+    event character varying(255) NOT NULL,
+    whodunnit character varying(255),
+    object text,
+    object_changes text,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE versions_id_seq OWNED BY versions.id;
 
 
 --
@@ -373,7 +441,21 @@ ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclas
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY teams ALTER COLUMN id SET DEFAULT nextval('teams_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq'::regclass);
 
 
 --
@@ -425,11 +507,27 @@ ALTER TABLE ONLY tags
 
 
 --
+-- Name: teams_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY teams
+    ADD CONSTRAINT teams_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY versions
+    ADD CONSTRAINT versions_pkey PRIMARY KEY (id);
 
 
 --
@@ -510,6 +608,13 @@ CREATE UNIQUE INDEX index_tags_on_slug ON tags USING btree (slug);
 
 
 --
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (item_type, item_id);
+
+
+--
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -562,9 +667,9 @@ INSERT INTO schema_migrations (version) VALUES ('20140602153320');
 
 INSERT INTO schema_migrations (version) VALUES ('20140606204236');
 
-INSERT INTO schema_migrations (version) VALUES ('20140607045935');
-
 INSERT INTO schema_migrations (version) VALUES ('20140923231243');
+
+INSERT INTO schema_migrations (version) VALUES ('20141020032733');
 
 INSERT INTO schema_migrations (version) VALUES ('20141111222212');
 
@@ -579,4 +684,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150328040918');
 INSERT INTO schema_migrations (version) VALUES ('20150328074815');
 
 INSERT INTO schema_migrations (version) VALUES ('20150416104151');
+
+INSERT INTO schema_migrations (version) VALUES ('20150714075016');
+
+INSERT INTO schema_migrations (version) VALUES ('20150714075047');
 


### PR DESCRIPTION
Users can now be associated with a team.

The team can have a name and a shtick just like normal authors but
nothing else to keep things simple.

Eventually I'd like to have teams be displayed the same way Guides are
currently, as a mosaic of blocks with the name of the team, the shtick
and small circle avatars of each team member up to a reasonable limit.

Curious what @drewbarontini and @johndjameson will think of this one. :-)

Still some WIP on this: 
- [ ] finish team index page
- [ ] finish team show page
- [ ] add team edit page
- [ ] display author's team in author show and index pages