### PR TITLE
Fix logentries addon for Heroku button

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
   "addons": [
     "scheduler:standard",
     "heroku-postgresql:hobby-dev",
-    "logentries:tryit"
+    "logentries:le_tryit"
   ],
   "env": {
     "ORIENTATION_LOGO": "/assets/default_logo.svg",


### PR DESCRIPTION
The Heroku button isn't working currently due to an invalid plan for the `logentries` addon:

<img width="382" alt="screenshot 2015-08-04 22 01 43" src="https://cloud.githubusercontent.com/assets/272702/9077496/7fdd579e-3af4-11e5-9447-e5d0b5607c53.png">

Tested locally and found that the "TryIt" plan should be referenced by `le_tryit` instead of just `tryit`...

![orientation-logentries](https://cloud.githubusercontent.com/assets/272702/9077485/517aa3ca-3af4-11e5-9197-a17034a7cc92.png)