### PR TITLE
Switch to .any? for checking if has_many associations have records

### DIFF
--- a/app/views/articles/_article.html.haml
+++ b/app/views/articles/_article.html.haml
@@ -1,7 +1,7 @@
-%li.card.list-item.article.has-signal{ class: ('has-article-footer' unless article.tags.empty? )}
+%li.card.list-item.article.has-signal{ class: ('has-article-footer' if article.tags.any? )}
   = article.signal
   = link_to article.title, article, class: 'article-title'
-  - unless article.tags.empty?
+  - if article.tags.any?
     .article-footer
       %ul.list.list--inline.list--inline--xs
         - article.tags.each do |t|

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -45,7 +45,7 @@
           - # TODO: Apply signal classes unique to Article decorator
           %ul.list.list--xs.mbl
             - @author.articles.each do | article |
-              %li.card.list-item.article{ class: ( 'has-article-footer' unless article.tags.empty? ) }
+              %li.card.list-item.article{ class: ( 'has-article-footer' if article.tags.any? ) }
                 = link_to article.title, article, class: 'article-title'
         - else
           - if current_user == @author
@@ -59,7 +59,7 @@
         - if @author.edits.count > 0
           %ul.list.list--xs.mbl
             - @author.edits.each do | article |
-              %li.card.list-item.article{ class: ( 'has-article-footer' unless article.tags.empty? ) }
+              %li.card.list-item.article{ class: ( 'has-article-footer' if article.tags.any? ) }
                 = link_to article.title, article, class: 'article-title'
         - else
           %p #{ @author.first_name } hasn't edited any articles yet.
@@ -68,7 +68,7 @@
         - if @author.subscribed_articles.count > 0
           %ul.list.list--xs
             - @author.subscribed_articles.each do | article |
-              %li.card.list-item.article{ class: ( 'has-article-footer' unless article.tags.empty? ) }
+              %li.card.list-item.article{ class: ( 'has-article-footer' if article.tags.any? ) }
                 = link_to article.title, article, class: 'article-title'
         - else
           %p #{ @author.first_name } isn't subscribed to any articles yet.

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -3,7 +3,7 @@
 
     %h1.mbs= @tag
 
-    - unless @tag.articles.empty?
+    - if @tag.articles.any?
       %ul.list.list--xs
         - @tag.articles.each do |article|
           - # TODO: Add Article fresh/stale/rotten signals


### PR DESCRIPTION
The `unless .empty?` checks would load the associations into objects, even if we didn't need them, whereas using `if .any?` will use the `.size` of the loaded record array if available, or issue a COUNT query to the database instead.

Sorry I didn't get back to this for so long! This is my newer, better thought-out solution to #148.