### PR TITLE
Automatic counter caches using has_many :through

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -131,9 +131,8 @@ class Article < ActiveRecord::Base
   end
 
   def self.reset_tags_count
-    self.all.each do |article|
-      tag_count = article.tags.count
-      article.update_attribute(:tags_count, tag_count)
+    pluck(:id).each do |article_id|
+      reset_counters(article_id, :tags)
     end
   end
 

--- a/app/models/articles_tag.rb
+++ b/app/models/articles_tag.rb
@@ -1,0 +1,6 @@
+class ArticlesTag < ActiveRecord::Base
+  belongs_to :article, counter_cache: :tags_count
+  belongs_to :tag, counter_cache: :articles_count
+
+  validates :article_id, uniqueness: { scope: :tag_id, case_sensitive: false }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,9 +27,8 @@ class Tag < ActiveRecord::Base
   end
 
   def self.reset_articles_count
-    self.all.each do |tag|
-      article_count = tag.articles.count
-      tag.update_attribute(:articles_count, article_count)
+    pluck(:id).each do |tag_id|
+      reset_counters(tag_id, :articles)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,8 +1,6 @@
 class Tag < ActiveRecord::Base
-  has_and_belongs_to_many :articles, -> { uniq }, counter_cache: :tags_count, before_add: :validates_article
-
-  after_create :increment_articles_counter
-  before_destroy :decrement_articles_counter
+  has_many :articles_tags, dependent: :destroy
+  has_many :articles, through: :articles_tags, counter_cache: :articles_count
 
   validates :name, uniqueness: true
 
@@ -35,25 +33,4 @@ class Tag < ActiveRecord::Base
     end
   end
 
-  private
-
-  def validates_article(article)
-    self.articles.include?(article)
-  end
-
-  def increment_articles_counter
-    self.articles.each do |article|
-      article.increment!(:tags_count)
-    end
-  end
-
-  ## I haven't tested the callback on this, but it should work. What I am not 100% sure of is if the record is saved even
-  ## a destroy, such that we can call `self.articles` on that same record and it works. If it doesn't work, then this can just
-  ## be moved to a 'before_destroy'.
-
-  def decrement_articles_counter
-    self.articles.each do |article|
-      article.decrement!(:tags_count)
-    end
-  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,7 +2,7 @@ class Tag < ActiveRecord::Base
   has_many :articles_tags, dependent: :destroy
   has_many :articles, through: :articles_tags, counter_cache: :articles_count
 
-  validates :name, uniqueness: true
+  validates :name, uniqueness: { case_sensitive: false }
 
   def to_s
     name

--- a/db/migrate/20150829203748_add_id_to_articles_tags.rb
+++ b/db/migrate/20150829203748_add_id_to_articles_tags.rb
@@ -1,0 +1,5 @@
+class AddIdToArticlesTags < ActiveRecord::Migration
+  def change
+    add_column :articles_tags, :id, :primary_key
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -127,12 +127,12 @@ ALTER SEQUENCE article_subscriptions_id_seq OWNED BY article_subscriptions.id;
 
 CREATE TABLE articles (
     id integer NOT NULL,
-    title character varying(255),
+    title character varying,
     content text,
     author_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    slug character varying(255),
+    slug character varying,
     editor_id integer,
     last_notified_author_at timestamp without time zone,
     archived_at timestamp without time zone,
@@ -170,8 +170,28 @@ ALTER SEQUENCE articles_id_seq OWNED BY articles.id;
 
 CREATE TABLE articles_tags (
     article_id integer,
-    tag_id integer
+    tag_id integer,
+    id integer NOT NULL
 );
+
+
+--
+-- Name: articles_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE articles_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: articles_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE articles_tags_id_seq OWNED BY articles_tags.id;
 
 
 --
@@ -187,8 +207,8 @@ CREATE TABLE delayed_jobs (
     run_at timestamp without time zone,
     locked_at timestamp without time zone,
     failed_at timestamp without time zone,
-    locked_by character varying(255),
-    queue character varying(255),
+    locked_by character varying,
+    queue character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -251,7 +271,7 @@ ALTER SEQUENCE friendly_id_slugs_id_seq OWNED BY friendly_id_slugs.id;
 --
 
 CREATE TABLE schema_migrations (
-    version character varying(255) NOT NULL
+    version character varying NOT NULL
 );
 
 
@@ -261,10 +281,10 @@ CREATE TABLE schema_migrations (
 
 CREATE TABLE tags (
     id integer NOT NULL,
-    name character varying(255),
+    name character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    slug character varying(255),
+    slug character varying,
     articles_count integer DEFAULT 0 NOT NULL
 );
 
@@ -294,17 +314,16 @@ ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 CREATE TABLE users (
     id integer NOT NULL,
-    provider character varying(255),
-    uid character varying(255),
-    name character varying(255),
-    email character varying(255),
+    provider character varying,
+    uid character varying,
+    name character varying,
+    email character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    image character varying(255),
-    avatar character varying(255),
+    image character varying,
+    avatar character varying,
     active boolean DEFAULT true,
-    shtick text,
-    articles_count integer DEFAULT 0 NOT NULL
+    shtick text
 );
 
 
@@ -346,6 +365,13 @@ ALTER TABLE ONLY article_subscriptions ALTER COLUMN id SET DEFAULT nextval('arti
 --
 
 ALTER TABLE ONLY articles ALTER COLUMN id SET DEFAULT nextval('articles_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY articles_tags ALTER COLUMN id SET DEFAULT nextval('articles_tags_id_seq'::regclass);
 
 
 --
@@ -398,6 +424,14 @@ ALTER TABLE ONLY article_subscriptions
 
 ALTER TABLE ONLY articles
     ADD CONSTRAINT articles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: articles_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY articles_tags
+    ADD CONSTRAINT articles_tags_pkey PRIMARY KEY (id);
 
 
 --
@@ -562,8 +596,6 @@ INSERT INTO schema_migrations (version) VALUES ('20140602153320');
 
 INSERT INTO schema_migrations (version) VALUES ('20140606204236');
 
-INSERT INTO schema_migrations (version) VALUES ('20140607045935');
-
 INSERT INTO schema_migrations (version) VALUES ('20140923231243');
 
 INSERT INTO schema_migrations (version) VALUES ('20141111222212');
@@ -579,4 +611,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150328040918');
 INSERT INTO schema_migrations (version) VALUES ('20150328074815');
 
 INSERT INTO schema_migrations (version) VALUES ('20150416104151');
+
+INSERT INTO schema_migrations (version) VALUES ('20150829203748');
 


### PR DESCRIPTION
This attempts to clean up some of the `Article` and `Tag` code by refactoring the manual increment/decrement of `tags_count` and `article_count` to use auto-magic from rails.

It changes the relationships between those models to use `has_many :through` relationships to a new model, `ArticlesTag`, and moves the tag uniqueness to validations on `Tag` and `ArticlesTag`.

The long commit messages can tell you even more!

I wasn't sure if the `validates_tag` and `validates_article` were needed, so I removed them. I can add them back if needed.