### PR TITLE
Validate title and show/select author.

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -25,6 +25,8 @@ class Article < ActiveRecord::Base
 
   attr_reader :tag_tokens
 
+  validates :title, presence: true
+
   after_save :update_subscribers
   after_save :notify_slack
   after_create :increment_tags_counter

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -21,6 +21,12 @@
 
             = f.input_field :content, rows: 12, class: 'form-input form-textarea js-editor-textarea'
 
+         .form-field
+           = f.label :author do
+             %span.form-label.label Author
+             - user_id = @article.new_record? ? current_user.id : @article.author_id
+             = f.input_field :author_id, collection: User.active.order(:name), include_blank: false, selected: user_id
+
         .form-field
           = f.label :tag_tokens do
             %span.form-label.label Tags

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -21,11 +21,11 @@
 
             = f.input_field :content, rows: 12, class: 'form-input form-textarea js-editor-textarea'
 
-         .form-field
-           = f.label :author do
-             %span.form-label.label Author
-             - user_id = @article.new_record? ? current_user.id : @article.author_id
-             = f.input_field :author_id, collection: User.active.order(:name), include_blank: false, selected: user_id
+        .form-field
+          = f.label :author do
+            %span.form-label.label Author
+            - user_id = @article.new_record? ? current_user.id : @article.author_id
+            = f.input_field :author_id, collection: User.active.order(:name), include_blank: false, selected: user_id
 
         .form-field
           = f.label :tag_tokens do

--- a/app/views/articles/new.html.haml
+++ b/app/views/articles/new.html.haml
@@ -1,4 +1,4 @@
-- if !@article.valid?
+- if !@article.valid? && !@article.new_record?
   %p.bulletin.bulletin--warning
     There's already an article with this title.
 

--- a/spec/models/article_search_spec.rb
+++ b/spec/models/article_search_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Article do
 
       before { article.tags << tag }
 
-      it "matches first based on the tag name" do
+      it "doesn't match based on tag name" do
         result = Article.text_search tag.name
-        expect(result.first).to eq(article)
+        expect(result.first).to be nil
       end
 
       context "when some articles include the tag name in their title" do


### PR DESCRIPTION
Validates there's a title present, an article without a title can't be selected from the listing therefore it is hard to edit.

Also allows you to pick an author for an article (useful when migrating from another wiki). Defaults the author to the currently logged in user.