### PR TITLE
Allow restrictions to login by specific domain.

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -6,6 +6,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     prompt: "select_account",
     image_aspect_ratio: "square",
     # we're displaying at 80 pixels, this is for high density ("Retina") displays
-    image_size: 160
+    image_size: 160,
+    hd: ENV["OAUTH2_RESTRICTED_DOMAIN"] || ""
   }
 end

--- a/spec/models/article_search_spec.rb
+++ b/spec/models/article_search_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Article do
 
       before { article.tags << tag }
 
-      it "matches first based on the tag name" do
+      it "doesn't match based on tag name" do
         result = Article.text_search tag.name
-        expect(result.first).to eq(article)
+        expect(result.first).to be nil
       end
 
       context "when some articles include the tag name in their title" do


### PR DESCRIPTION
This is a function of omniauth/google's API which is poorly documented and probably required for 100% of the private wikis. 