### PR TITLE
FriendlyId regeneration logic adjustment

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,7 +8,11 @@ class Article < ActiveRecord::Base
   friendly_id :title, use: [:slugged, :history]
 
   def should_generate_new_friendly_id?
-    !has_friendly_id_slug? or title_changed?
+    persisted? && (missing_friendly_id_slug? || title_changed?)
+  end
+
+  def missing_friendly_id_slug?
+    !has_friendly_id_slug?
   end
 
   def has_friendly_id_slug?


### PR DESCRIPTION
This logic is causing new slugs to be generated way more times than
necessary.