### PR TITLE
Smart (relative) links based on article title or slug

### DIFF
--- a/app/assets/stylesheets/foundation/_config.sass
+++ b/app/assets/stylesheets/foundation/_config.sass
@@ -94,6 +94,7 @@ $form-input--clear-color: $chicago
 
 $article-title-color: lighten($chicago, 15%)
 $article-title--state-color: darken($article-title-color, 20%)
+$article-link-not-found-color: $c-error
 
 // Bulletin
 

--- a/app/assets/stylesheets/structures/_article.sass
+++ b/app/assets/stylesheets/structures/_article.sass
@@ -52,3 +52,8 @@
 
   +state
     color: $article-title--state-color
+
+// ----- Content ----- //
+
+.article-not-found
+  color: $article-link-not-found-color

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,10 +24,19 @@ module ApplicationHelper
     end
 
     def link(link, title, content)
-      class_attribute = "class='#{article_status(link)}'" if internal_link?(link)
+      if internal_link?(link) && !valid_article?(link)
+        class_attribute = "class='#{article_status(link)}'"
+      end
       title_attribute = "title='#{title}'" if title
 
-      "<a href='#{link}' #{title_attribute} #{class_attribute}>#{content}</a>"
+      if class_attribute || title_attribute
+        "<a href='#{link}' #{title_attribute} #{class_attribute}>#{content}</a>"
+      else
+        # Redcarpet doesn't allow calls to super in overidden
+        # render methods due to C shenanigans:
+        # https://github.com/vmg/redcarpet/issues/51#issuecomment-1922079
+        "<a href='#{link}'>#{content}</a>"
+      end
     end
 
     def normal_text(text)
@@ -55,11 +64,7 @@ module ApplicationHelper
     private
 
     def article_status(link)
-      if valid_article?(link)
-        'article-found'
-      else
-        'article-not-found'
-      end
+      'article-not-found' if !valid_article?(link)
     end
 
     def article_link(article_title)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,11 +23,48 @@ module ApplicationHelper
       end
     end
 
+    def link(link, title, content)
+      class_attribute = "class='#{article_status(link)}'" if internal_link?(link)
+      title_attribute = "title='#{title}'" if title
+
+      "<a href='#{link}' #{title_attribute} #{class_attribute}>#{content}</a>"
+    end
+
     def normal_text(text)
       text.gsub!("[ ]", "<input type='checkbox'>") if text.match(/^\[{1}\s\]{1}/)
       text.gsub!("[x]", "<input type='checkbox' checked>") if text.match(/^\[{1}(x|X)\]{1}/)
 
       text
+    end
+
+    private
+
+    def article_status(link)
+      if valid_article?(link)
+        'article-found'
+      else
+        'article-not-found'
+      end
+    end
+
+    def internal_link?(link)
+      url = URI.parse(link)
+
+      if url.absolute?
+        root = Rails.application.routes.url_helpers.root_url(host: ENV.fetch("ORIENTATION_DOMAIN"))
+        link.include?(root)
+      else
+        true
+      end
+    end
+
+    def valid_article?(link)
+      link = URI.parse(link).path if !internal_link?(link)
+      slug = link.split('/').last
+
+      Article.friendly.find(slug)
+    rescue ActiveRecord::RecordNotFound
+      false
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,21 @@ module ApplicationHelper
       text
     end
 
+    def paragraph(text)
+      # matches [[Article Title]] or [[article-title]] relative
+      # links, see https://regex101.com/r/aR5bS0/1
+      pattern = /\[{2}(.*?)\]{2}/
+
+      if text.match(pattern)
+        text.gsub!(pattern) do
+          text = Regexp.last_match[1]
+          link(article_link(text.parameterize), nil, text)
+        end
+      else
+        text
+      end
+    end
+
     private
 
     def article_status(link)
@@ -45,6 +60,10 @@ module ApplicationHelper
       else
         'article-not-found'
       end
+    end
+
+    def article_link(article_title)
+      Rails.application.routes.url_helpers.article_url(article_title, only_path: true)
     end
 
     def internal_link?(link)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  include ApplicationHelper
+
+  describe "#markdown(text)" do
+    let(:article) { create(:article) }
+
+    it "converts the explicit markdown link to HTML" do
+      article.update!(content: "[link](http://example.org)")
+      expect(markdown(article.content)).to include("<a href='http://example.org'>link</a>")
+    end
+
+    it "converts the implicit markdown slug link (to an invalid article) to HTML" do
+      article.update!(content: "[[link]]")
+      expect(markdown(article.content)).to include("<a href='/articles/link'  class='article-not-found'>link</a>")
+    end
+
+    it "converts the implicit markdown slug link (to a valid article) to HTML" do
+      article.update!(title: "link", content: "[[link]]")
+      expect(markdown(article.content)).to include("<a href='/articles/link'>link</a>")
+    end
+
+    it "converts the implicit markdown title link (to a valid article) to HTML" do
+      article.update!(title: "This is a title", content: "[[This is a title]]")
+      expect(markdown(article.content)).to include("<a href='/articles/this-is-a-title'>This is a title</a>")
+    end
+  end
+end


### PR DESCRIPTION
Finally tackles a long standing problem with outdated links described
in #82.

Since we now have article slug history trackling (if you rename
an article, its original slug & title will still take you to it) this feature
is ready for prime time.

It's now possible to link to any article either via its full title or its slug:

```markdown
[[This is an article title]]

[[this-is-an-article-slug]]
```

This is especially convenient because it takes domains and paths
out of the equation.

However, I'll need to make a rake task to migrate existing URLs that
match valid article titles and hardcode the `ORIENTATION_DOMAIN`
or use relative paths.