### PR TITLE
Revert "FriendlyId regeneration logic adjustment"

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,11 +8,7 @@ class Article < ActiveRecord::Base
   friendly_id :title, use: [:slugged, :history]
 
   def should_generate_new_friendly_id?
-    persisted? && (missing_friendly_id_slug? || title_changed?)
-  end
-
-  def missing_friendly_id_slug?
-    !has_friendly_id_slug?
+    !has_friendly_id_slug? or title_changed?
   end
 
   def has_friendly_id_slug?


### PR DESCRIPTION
Reverts orientation/orientation#167

@mattpolito The code you added is causing @article.slug to be `nil` [in this method](https://github.com/orientation/orientation/blob/master/app/controllers/articles_controller.rb#L171), which is what causes the routing error because `Article#to_param` returns `slug` and we need it to be generated before redirection.

I managed to reproduce this by cleaning up the article feature spec. I'll push that so you can too.