### PR TITLE
Log rot reporter & mention them in notification

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -86,7 +86,7 @@ class ArticlesController < ApplicationController
   end
 
   def report_rot
-    @article.rot!
+    @article.rot!(current_user.id)
     flash[:notice] = "Successfully reported this article as rotten."
     respond_with_article_or_redirect
   end

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -51,6 +51,14 @@ class ArticleDecorator < ApplicationDecorator
     content_tag(:span, "rotten", class: "state rotten") if source.rotten?
   end
 
+  def rot_reporter
+    link_to AuthorDecorator.new(source.rot_reporter), author_url(source.author)
+  end
+
+  def rotted_at
+    source.rotted_at.to_date.to_s(:long_ordinal)
+  end
+
   def signal
     state = 'fresh' if source.fresh?
     state = 'stale' if source.stale?

--- a/app/jobs/send_article_rotten_job.rb
+++ b/app/jobs/send_article_rotten_job.rb
@@ -1,6 +1,8 @@
-class SendArticleRottenJob < Struct.new(:article_id, :contributors)
+class SendArticleRottenJob < Struct.new(:article_id, :reporter_id)
   def perform
     article = Article.find(article_id)
-    ArticleMailer.send_rotten_notification_for(article, contributors).deliver
+    reporter = User.find(reporter_id)
+    contributors = article.contributors
+    ArticleMailer.send_rotten_notification_for(article, contributors, reporter).deliver
   end
 end

--- a/app/mailers/article_mailer.rb
+++ b/app/mailers/article_mailer.rb
@@ -33,14 +33,16 @@ class ArticleMailer < MandrillMailer::TemplateMailer
                   }
   end
 
-  def send_rotten_notification_for(article, contributors)
+  def send_rotten_notification_for(article, contributors, reporter)
     mandrill_mail template: 'article-rotten-update',
-                  subject: 'Article Rotten Update',
+                  subject: "#{reporter.name} marked #{article.title} as rotten",
                   from_name: 'Orientation',
                   to: contributors,
                   vars: {
                     'ARTICLE_TITLE' => article.title,
-                    'URL' => article_url(article)
+                    'URL' => article_url(article),
+                    'REPORTER_NAME' => reporter.name,
+                    'REPORTER_URL' => author_url(reporter)
                   }
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -9,13 +9,14 @@ class Article < ActiveRecord::Base
 
   belongs_to :author, class_name: "User"
   belongs_to :editor, class_name: "User"
+  belongs_to :rot_reporter, class_name: "User"
+  
   has_many :articles_tags, dependent: :destroy
   has_many :tags, through: :articles_tags, counter_cache: :tags_count
   has_many :subscriptions, class_name: "ArticleSubscription", counter_cache: true, dependent: :destroy
   has_many :subscribers, through: :subscriptions, class_name: "User", source: :user
   has_many :endorsements, class_name: "ArticleEndorsement", counter_cache: true, dependent: :destroy
   has_many :endorsers, through: :endorsements, class_name: "User", source: :user
-  has_one :rot_reporter, class_name: "User", foreign_key: "rot_reporter_id"
 
   attr_reader :tag_tokens
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -15,6 +15,7 @@ class Article < ActiveRecord::Base
   has_many :subscribers, through: :subscriptions, class_name: "User", source: :user
   has_many :endorsements, class_name: "ArticleEndorsement", counter_cache: true, dependent: :destroy
   has_many :endorsers, through: :endorsements, class_name: "User", source: :user
+  has_one :rot_reporter, class_name: "User", foreign_key: "rot_reporter_id"
 
   attr_reader :tag_tokens
 
@@ -106,9 +107,9 @@ class Article < ActiveRecord::Base
     touch(:updated_at)
   end
 
-  def rot!
-    update_attribute(:rotted_at, Time.current)
-    Delayed::Job.enqueue(SendArticleRottenJob.new(self.id, contributors))
+  def rot!(user_id)
+    update(rotted_at: Time.current, rotted_by: user_id)
+    Delayed::Job.enqueue(SendArticleRottenJob.new(self.id, user_id))
   end
 
   def never_notified_author?

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -3,7 +3,7 @@
 - if @article.archived?
   %p.bulletin.bulletin--warning This article has been archived. Please don't trust the information displayed here.
 - if @article.rotten?
-  %p.bulletin.bulletin--warning This article has gone rotten. The information is partially or completely out-of-date.
+  %p.bulletin.bulletin--warning This article was report as rotten by #{@article.rot_reporter} on #{@article.rotted_at}. The information is partially or completely out-of-date.
 - if @article.stale?
   %p.bulletin.bulletin--notice.tct This article has gone stale. It hasn't been updated in a while so the information may be slightly out-of-date.
 

--- a/db/migrate/20150922194413_add_rot_reporter_id_to_articles.rb
+++ b/db/migrate/20150922194413_add_rot_reporter_id_to_articles.rb
@@ -1,0 +1,5 @@
+class AddRotReporterIdToArticles < ActiveRecord::Migration
+  def change
+    add_column :articles, :rot_reporter_id, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -142,6 +142,7 @@ CREATE TABLE articles (
     subscriptions_count integer DEFAULT 0,
     endorsements_count integer DEFAULT 0,
     visits integer DEFAULT 0 NOT NULL
+    rot_reporter_id integer
 );
 
 
@@ -613,4 +614,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150328074815');
 INSERT INTO schema_migrations (version) VALUES ('20150416104151');
 
 INSERT INTO schema_migrations (version) VALUES ('20150829203748');
+
+INSERT INTO schema_migrations (version) VALUES ('20150922194413');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -141,7 +141,7 @@ CREATE TABLE articles (
     guide boolean DEFAULT false,
     subscriptions_count integer DEFAULT 0,
     endorsements_count integer DEFAULT 0,
-    visits integer DEFAULT 0 NOT NULL
+    visits integer DEFAULT 0 NOT NULL,
     rot_reporter_id integer
 );
 
@@ -614,6 +614,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150328074815');
 INSERT INTO schema_migrations (version) VALUES ('20150416104151');
 
 INSERT INTO schema_migrations (version) VALUES ('20150829203748');
+
+INSERT INTO schema_migrations (version) VALUES ('20150921154734');
 
 INSERT INTO schema_migrations (version) VALUES ('20150922194413');
 

--- a/spec/jobs/send_article_rotten_job_spec.rb
+++ b/spec/jobs/send_article_rotten_job_spec.rb
@@ -1,16 +1,15 @@
 require "rails_helper"
 
-RSpec.describe SendArticleUpdateJob do
-  let!(:article) { create(:article) }
-  let!(:user) { create(:user) }
-
-  let(:job) { described_class.new(article.id, user.id) }
-  subject(:perform_job) { job.perform }
-
+RSpec.describe SendArticleRottenJob do
   it "sends an ArticleMailer" do
-    mailer = double("ArticleMailer", deliver: true)
+    article       = create(:article)
+    reporter      = create(:user)
+    contributors  = article.contributors
+    mailer        = double("ArticleMailer", deliver: true)
 
-    expect(ArticleMailer).to receive(:send_updates_for).and_return(mailer)
-    perform_job
+    expect(ArticleMailer).to receive(:send_rotten_notification_for)
+      .with(article, contributors, reporter).and_return(mailer)
+
+    described_class.perform_now(article.id, reporter.id)
   end
 end

--- a/spec/jobs/send_article_rotten_job_spec.rb
+++ b/spec/jobs/send_article_rotten_job_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe SendArticleUpdateJob do
+  let!(:article) { create(:article) }
+  let!(:user) { create(:user) }
+
+  let(:job) { described_class.new(article.id, user.id) }
+  subject(:perform_job) { job.perform }
+
+  it "sends an ArticleMailer" do
+    mailer = double("ArticleMailer", deliver: true)
+
+    expect(ArticleMailer).to receive(:send_updates_for).and_return(mailer)
+    perform_job
+  end
+end

--- a/spec/jobs/send_article_update_job_spec.rb
+++ b/spec/jobs/send_article_update_job_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe SendArticleUpdateJob do
     expect(ArticleMailer).to receive(:send_updates_for)
       .with(article, user).and_return(mailer)
 
-    described_class.perform_now(article, user)
+    described_class.perform_now(article.id, user.id)
   end
 end

--- a/spec/mailers/article_mailer_spec.rb
+++ b/spec/mailers/article_mailer_spec.rb
@@ -41,14 +41,15 @@ RSpec.describe ArticleMailer do
         { name: user.name, email: user.email }
       end
     end
+    let(:reporter) { create(:user) }
 
-    let(:mailer) { described_class.send_rotten_notification_for(article, contributors) }
+    let(:mailer) { described_class.send_rotten_notification_for(article, contributors, reporter) }
 
     subject { mailer }
 
     it { is_expected.to send_email_to(email: contributors.first[:email]) }
     it { is_expected.to use_template('article-rotten-update') }
-    it { is_expected.to have_subject('Article Rotten Update') }
+    it { is_expected.to have_subject("#{reporter.name} marked #{article.title} as rotten") }
     it { is_expected.to be_from(email: 'orientation@codeschool.com') }
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -298,8 +298,10 @@ RSpec.describe Article do
     end
   end
 
-  describe "#rot!" do
-    subject(:rot!) { article.rot! }
+  describe "#rot!(user_id)" do
+    let(:reporter) { create(:user) }
+
+    subject(:rot!) { article.rot!(reporter.id) }
 
     context 'with a fresh article' do
       let(:article) { create(:article, :fresh) }


### PR DESCRIPTION
Now when someone reports an article as rotten we log who it was.

Why?
- it makes things more human, it's not just a game of whack-a-mole to
find articles and mark them as rotten
- it allows for conversations to happen between the reporter and the
article contributors
- if notifications are turned off it allows a reader or contributor of the
article to reach out to the rot reporter in order to refresh the article

This commit also refactors the ArticleRottenJob to put all the fetching
logic inside of it. We don't pass a contributors object, or an article, or
a reporter. All of those are fetched at job runtime.

I'll have to update the Mandrill templates in order to use the now
added REPORTER_NAME and REPORTER_URL merge vars.

Fixes #178