### PR TITLE
Add content validation and crud specs for articles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :test do
   gem 'database_cleaner'
   gem 'capybara'
+  gem 'launchy'
   gem 'codeclimate-test-reporter', require: nil
   gem 'climate_control'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (6.0.3)
     autoprefixer-rails (5.1.8.1)
       execjs
@@ -135,6 +136,8 @@ GEM
     json (1.8.3)
     jwt (1.4.1)
     kgio (2.9.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (2.9.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -337,6 +340,7 @@ DEPENDENCIES
   friendly_id
   gemoji
   haml-rails
+  launchy
   mandrill_mailer
   omniauth
   omniauth-google-oauth2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,6 @@ class ApplicationController < ActionController::Base
       if !Rails.env.production?
         user = User.first_or_create(email: "alvar@hanso.dk", name: "Alvar Hanso")
         session[:user_id] = user.id
-        flash[:notice] = "Signed in!"
       else
         user = User.find(session[:user_id]) if session[:user_id].present?
       end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -31,12 +31,8 @@ class ArticlesController < ApplicationController
 
   def create
     @article = Article.new(article_params)
-    if @article.save
-      @article.subscribe_author
-      respond_with_article_or_redirect
-    else
-      render :new
-    end
+    @article.subscribe_author if @article.save
+    respond_with @article
   end
 
   def edit
@@ -93,7 +89,7 @@ class ArticlesController < ApplicationController
   end
 
   def update
-    respond_with_article_or_redirect if @article.update_attributes(article_params)
+    respond_with @article if @article.update_attributes(article_params)
   end
 
   def destroy

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -140,7 +140,7 @@ class ArticlesController < ApplicationController
     if article.errors.messages.key?(:friendly_id)
       "#{article.title} is a reserved word."
     else
-      "Article could not be #{params[:action]}ed."
+      "Article could not be #{params[:action]}d."
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -31,7 +31,12 @@ class ArticlesController < ApplicationController
 
   def create
     @article = Article.new(article_params)
-    @article.subscribe_author if @article.save
+    if @article.save
+      @article.subscribe_author
+      flash[:notice] = "Article was successfully created."
+    else
+      flash[:error] = error_message(@article)
+    end
     respond_with @article
   end
 
@@ -89,7 +94,12 @@ class ArticlesController < ApplicationController
   end
 
   def update
-    respond_with @article if @article.update_attributes(article_params)
+    if @article.update_attributes(article_params)
+      flash[:notice] = "Article was successfully updated."
+    else
+      flash[:error] = error_message(@article)
+    end
+    respond_with @article
   end
 
   def destroy
@@ -125,6 +135,14 @@ class ArticlesController < ApplicationController
   end
 
   private
+
+  def error_message(article)
+    if article.errors.messages.key?(:friendly_id)
+      "#{article.title} is a reserved word."
+    else
+      "Article could not be #{params[:action]}ed."
+    end
+  end
 
   def article_params
     params.require(:article).permit(

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -183,10 +183,6 @@ class Article < ActiveRecord::Base
     title
   end
 
-  def to_param
-    slug
-  end
-
   def unarchive!
     update_attribute(:archived_at, nil)
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,7 +8,7 @@ class Article < ActiveRecord::Base
   belongs_to :author, class_name: "User"
   belongs_to :editor, class_name: "User"
   belongs_to :rot_reporter, class_name: "User"
-  
+
   has_many :articles_tags, dependent: :destroy
   has_many :tags, through: :articles_tags, counter_cache: :tags_count
   has_many :subscriptions, class_name: "ArticleSubscription", counter_cache: true, dependent: :destroy
@@ -19,6 +19,7 @@ class Article < ActiveRecord::Base
   attr_reader :tag_tokens
 
   validates :title, presence: true
+  validates :content, presence: true
 
   after_save :update_subscribers
   after_save :notify_slack

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -2,11 +2,11 @@ en:
   flash:
     actions:
       create:
-        notice: '%{resource_name} was successfully created.'
+        #notice: '%{resource_name} was successfully created.'
         # alert: '%{resource_name} could not be created.'
       update:
-        notice: '%{resource_name} was successfully updated.'
+        #notice: '%{resource_name} was successfully updated.'
         # alert: '%{resource_name} could not be updated.'
       destroy:
-        notice: '%{resource_name} was successfully destroyed.'
-        alert: '%{resource_name} could not be destroyed.'
+        #notice: '%{resource_name} was successfully destroyed.'
+        # alert: '%{resource_name} could not be destroyed.'

--- a/spec/features/creating_an_article_spec.rb
+++ b/spec/features/creating_an_article_spec.rb
@@ -36,13 +36,14 @@ RSpec.describe "Creating an article" do
 
     context "with a reserved keyword" do
       before do
-        fill_in "article_title", with: "New"
+        fill_in "article_title", with: "new"
         fill_in "article_content", with: "Here is some content"
         click_button "Create Article"
       end
 
       it "renders the new article page" do
         expect(page).to have_content("Create a New Article")
+        expect(page).to have_content("new is a reserved word.")
       end
     end
   end

--- a/spec/features/creating_an_article_spec.rb
+++ b/spec/features/creating_an_article_spec.rb
@@ -1,22 +1,49 @@
 require "rails_helper"
 
-RSpec.describe 'Creating an article' do
+RSpec.describe "Creating an article" do
   before { visit new_article_path }
 
   context "with valid parameters" do
     before do
       fill_in "article_title", with: "Test"
       fill_in "article_content", with: "This is a test"
-      click_button 'Create Article'
+      click_button "Create Article"
     end
 
-    it "doesn't redirect to the new article page" do
+    it "does not redirect to the new article page" do
       expect(current_path).to_not eq(new_article_path)
+      expect(page).to have_content "Article was successfully created."
     end
 
     it "the author is subscribed" do
       last_article = Article.last
       expect(last_article.subscriptions.last.user).to eq(last_article.author)
+    end
+  end
+
+  context "with invalid parameters" do
+    context "with no content" do
+      before do
+        fill_in "article_title", with: "Test"
+        fill_in "article_content", with: ""
+        click_button "Create Article"
+      end
+
+      it "renders the new article page" do
+        expect(page).to have_content("Create a New Article")
+      end
+    end
+
+    context "with a reserved keyword" do
+      before do
+        fill_in "article_title", with: "New"
+        fill_in "article_content", with: "Here is some content"
+        click_button "Create Article"
+      end
+
+      it "renders the new article page" do
+        expect(page).to have_content("Create a New Article")
+      end
     end
   end
 end

--- a/spec/features/creating_an_article_spec.rb
+++ b/spec/features/creating_an_article_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Creating an article" do
       click_button "Create Article"
     end
 
-    it "does not redirect to the new article page" do
+    it "doesn't redirect to the new article page" do
       expect(current_path).to_not eq(new_article_path)
       expect(page).to have_content "Article was successfully created."
     end

--- a/spec/features/updating_an_article_spec.rb
+++ b/spec/features/updating_an_article_spec.rb
@@ -16,4 +16,31 @@ RSpec.describe "Updating an article" do
       expect(page).to have_content 'Article was successfully updated.'
     end
   end
+
+  context "with invalid parameters" do
+    context "with no content" do
+      before do
+        fill_in "article_title", with: "Test"
+        fill_in "article_content", with: ""
+        click_button "Update Article"
+      end
+
+      it "renders the edit article page" do
+        expect(page).to have_content("Edit an Article")
+      end
+    end
+
+    context "with a reserved keyword" do
+      before do
+        fill_in "article_title", with: "javascripts"
+        fill_in "article_content", with: "Here is some content"
+        click_button "Update Article"
+      end
+
+      it "renders the new article page" do
+        expect(page).to have_content("Edit an Article")
+        expect(page).to have_content("javascripts is a reserved word.")
+      end
+    end
+  end
 end

--- a/spec/features/updating_an_article_spec.rb
+++ b/spec/features/updating_an_article_spec.rb
@@ -16,16 +16,4 @@ RSpec.describe "Updating an article" do
       expect(page).to have_content 'Article was successfully updated.'
     end
   end
-
-  context "with invalid parameters" do
-    before do
-      fill_in "article_title", with: "Test"
-      fill_in "article_content", with: ""
-      click_button "Update Article"
-    end
-
-    it "renders the edit article page" do
-      expect(page).to have_content("Edit An Article")
-    end
-  end
 end

--- a/spec/features/updating_an_article_spec.rb
+++ b/spec/features/updating_an_article_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Updating an article" do
+  let(:article) { create(:article) }
+  before { visit edit_article_path(article) }
+
+  context "with valid parameters" do
+    before do
+      fill_in "article_title", with: "mexican food"
+      fill_in "article_content", with: "sounds good right now"
+      click_button "Update Article"
+    end
+
+    it "does not render the edit article page" do
+      expect(current_path).to_not eq(edit_article_path(article))
+      expect(page).to have_content 'Article was successfully updated.'
+    end
+  end
+
+  context "with invalid parameters" do
+    before do
+      fill_in "article_title", with: "Test"
+      fill_in "article_content", with: ""
+      click_button "Update Article"
+    end
+
+    it "renders the edit article page" do
+      expect(page).to have_content("Edit An Article")
+    end
+  end
+end

--- a/spec/features/viewing_an_article_spec.rb
+++ b/spec/features/viewing_an_article_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe 'Viewing an article' do
+RSpec.describe "Viewing an article" do
   let(:article) { create(:article) }
 
   subject(:article_visit) { visit article_path(article) }
@@ -8,4 +8,50 @@ RSpec.describe 'Viewing an article' do
   it "increments the visits for this article by 1" do
     expect { article_visit }.to change { article.reload.visits }.by(1)
   end
+
+  context "visitor visits an article" do
+    let(:article) { create(:article) }
+
+    before do
+      visit article_path(article)
+    end
+
+    it "shows the article" do
+      expect(page).to have_content(article.title)
+      expect(current_path).to eq(article_path(article))
+    end
+  end
+
+  context "visitor visits old slug" do
+    let(:article) { create(:article, title: "Old Title") }
+    let(:old_url) { article_path(article) }
+
+    before do
+      visit edit_article_path(article)
+      fill_in "article_title", with: "New Title"
+      click_button "Update Article"
+    end
+
+    it "redirects from the old url" do
+      new_url = "/articles/new-title"
+
+      visit old_url
+      expect(page).to have_content(article.reload.title)
+      expect(current_path).to eq(new_url)
+    end
+  end
+
+  context "visitor visits article url that does not exist" do
+    let(:title) { "Foo" }
+    before do
+      visit article_path(title)
+    end
+
+    it "redirects to the new article page with the title" do
+      expect(page).to have_content("Since this article doesn't exist, it would be super nice if you wrote it. :-)")
+      expect(current_path).to eq(new_article_path)
+    end
+  end
 end
+
+


### PR DESCRIPTION
Added integration specs for article CRUD. 

We needed to delete that 'sign in' flash from the application controller because it was overriding all the other flash messages in development.  

We added the launchy gem for capybara's save_and_open_page.  

We went ahead and removed the redirect logic from the create and update actions. Neither action was redirecting correctly or showing a flash message. Let us know if there is a use case we are missing here 