### PR TITLE
Smarter regex which will not convert emojis in code blocks and fenced

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def emojify(content)
-    content.gsub(/:([\w+-]+):/) do |match|
+    content.gsub(/:([\w+-]+):(?=([^`]*`[^`]*`)*[^`]*$)/) do |match|
       if emoji = Emoji.find_by_alias($1)
         %(<img alt="#$1" src="/images/emoji/#{emoji.image_filename}" style="vertical-align:middle" width="20" height="20" />)
       else

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -42,8 +42,13 @@ RSpec.describe ApplicationHelper do
     end
 
     it "does not convert emoji markdown inside inline code" do
-      article.update!(content: "This `:octocat:` emoji should not be converted.")
-      expect(markdown(article.content)).to include(":octocat:")
+      article.update!(content: "This `ocf:heartbeat:ip` emoji should not be converted.")
+      expect(markdown(article.content)).to include(":heartbeat:")
+    end
+
+    it "converts emoji markdown but does not convert emoji markdown in both fenced and inline" do
+      article.update!(content: "This ocf:heartbeat:ip should convert, however, this `ocf:heartbeat:ip` emoji should not be converted and neither should this ```ocf:hearthbeat:ip```")
+      expect(markdown(article.content)).to include("<p>This ocf<img alt="heartbeat" src="/images/emoji/unicode/1f493.png" style="vertical-align:middle" width="20" height="20" />ip should convert, however, this <code>ocf:heartbeat:ip</code> emoji should not be converted and neither should this <code>ocf:hearthbeat:ip</code></p>")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -30,5 +30,20 @@ RSpec.describe ApplicationHelper do
       article.update!(title: "This is a title", content: "[[This is a title]]")
       expect(markdown(article.content)).to include("<a href='/articles/this-is-a-title'>This is a title</a>")
     end
+
+    it "converts emoji markdown to HTML" do
+      article.update!(content: "This is a :octocat: emoji")
+      expect(markdown(article.content)).to include("<img alt=\"octocat\" src=\"/images/emoji/octocat.png\" style=\"vertical-align:middle\" width=\"20\" height=\"20\" />")
+    end
+
+    it "does not convert emoji markdown inside fenced code blocks" do
+      article.update!(content: "This should not convert ``` :octocat: ```.")
+      expect(markdown(article.content)).to include(":octocat")
+    end
+
+    it "does not convert emoji markdown inside inline code" do
+      article.update!(content: "This `:octocat:` emoji should not be converted.")
+      expect(markdown(article.content)).to include(":octocat:")
+    end
   end
 end


### PR DESCRIPTION
This PR will update the regex which converts emojis into images to ignore any code within inline or fenced code blocks. I am using the strategy of looking for an even number of backticks (if there are any) to determine that the matched pattern is not contained within a fenced in or inline code block. 

I doubt this is the *best* solution - but was the only one I could come up with on the regex side. A better long term solution may be to move the emoji conversion into a RedCarpet extension where we can control on which blocks it is evaluated.

I've also added specs to test for 3 cases:

1) convert emoji when not in either fenced or inline code block
2) do not convert emoji when in fenced code block
3) do not convert emoji when in inline code block