### PR TITLE
Display editors in article update notifications

### DIFF
--- a/app/jobs/send_article_update_job.rb
+++ b/app/jobs/send_article_update_job.rb
@@ -3,7 +3,7 @@ class SendArticleUpdateJob < ActiveJob::Base
 
   def perform(article_id, user_id)
     article = Article.find(article_id)
-    user    = User.find(user_id)
+    user = User.find(user_id)
 
     ArticleMailer.send_updates_for(article, user).deliver
   end

--- a/app/mailers/article_mailer.rb
+++ b/app/mailers/article_mailer.rb
@@ -24,12 +24,13 @@ class ArticleMailer < MandrillMailer::TemplateMailer
 
   def send_updates_for(article, user)
     mandrill_mail template: 'article-subscription-update',
-                  subject: "#{article.title} was just updated",
+                  subject: "#{article.title} was just updated by #{article.editor}",
                   from_name: 'Orientation',
                   to: { email: user.email, name: user.name },
                   vars: {
                     'ARTICLE_TITLE' => article.title,
-                    'URL' => article_url(article)
+                    'URL' => article_url(article),
+                    'EDITOR' => article.editor
                   }
   end
 

--- a/spec/mailers/article_mailer_spec.rb
+++ b/spec/mailers/article_mailer_spec.rb
@@ -22,15 +22,21 @@ RSpec.describe ArticleMailer do
     it { is_expected.to be_from(email: 'orientation@codeschool.com') }
   end
 
-  context ".send_updates_for(article, user)" do
+  context ".send_updates_for(article, user, editor)" do
     let(:article) { create(:article) }
+    let(:other_user) { create(:user) }
     let(:mailer) { described_class.send_updates_for(article, user) }
+
+    before do
+      article.editor = other_user
+      article.reload
+    end
 
     subject { mailer }
 
     it { is_expected.to send_email_to(email: user.email) }
     it { is_expected.to use_template('article-subscription-update') }
-    it { is_expected.to have_subject("#{article.title} was just updated") }
+    it { is_expected.to have_subject("#{article.title} was just updated by #{article.editor}") }
     it { is_expected.to be_from(email: 'orientation@codeschool.com') }
   end
 


### PR DESCRIPTION
This helps the team understands who's doing the work of upading articles
and naturally creates communication bridges to topic-experts.