### PR TITLE
Allow Tag creation on partial match

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -18,10 +18,13 @@ class Tag < ApplicationRecord
 
   def self.tokens(query)
     tags = where(%Q["tags"."name" ILIKE ?], "%#{query}%")
+    new_tag = {id: "<<<#{query}>>>", name: "New: \"#{query}\""}
     if tags.empty?
-      [{id: "<<<#{query}>>>", name: "New: \"#{query}\""}]
+      [new_tag]
     else
-      tags.collect{ |t| Hash["id" => t.id, "name" => t.name] }
+      results = tags.collect{ |t| Hash["id" => t.id, "name" => t.name] }
+      results.unshift(new_tag) if tags.select{|t| t.name.downcase == query.downcase}.empty?
+      results
     end
   end
 


### PR DESCRIPTION
- Currently behaviour prevents adding a new tag if there are any results returned
- This pull request allows creation of a new tag if it doesn't exist

**Old Behaviour**
![image](https://cloud.githubusercontent.com/assets/892961/17271262/7cb4d91c-56a9-11e6-9062-0695bf38574a.png)


**New Behaviour**
![image](https://cloud.githubusercontent.com/assets/892961/17271257/5dedfa4a-56a9-11e6-8f01-462fc05e9f3b.png)
