### PR TITLE
Fix build by updating Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: git://github.com/olivierlacan/simple_form.git
-  revision: f63ea975d3f8fd8f222f086f11ae10a4222fc250
+  revision: 86ab4252ecad1956fa2ddeea2d62a1584dac10f6
   branch: rails-5-type-for-attribute
   specs:
     simple_form (3.2.1)


### PR DESCRIPTION
Used this https://semaphoreci.com/docs/fail-could-not-parse-object.html to fix it

> This problem occurs when there have been changes like force-pushes to a git repo which is referenced in a Gemfile.

> The solution is is to comment that gem line in Gemfile, run bundle, uncomment it and bundle again. Then the Gemfile.lock will reference a valid git revision.


**Current build failing errors**
```
The command "eval bundle install --deployment --without development" failed. Retrying, 3 of 3.
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Fetching dependency metadata from https://rubygems.org/
Fetching git://github.com/olivierlacan/simple_form.git
fatal: Could not parse object 'f63ea975d3f8fd8f222f086f11ae10a4222fc250'.
Git error: command `git reset --hard f63ea975d3f8fd8f222f086f11ae10a4222fc250`
in directory
/home/travis/build/orientation/orientation/vendor/bundle/ruby/2.3.0/bundler/gems/simple_form-f63ea975d3f8
has failed.
If this error persists you could try removing the cache directory
'/home/travis/build/orientation/orientation/vendor/bundle/ruby/2.3.0/cache/bundler/git/simple_form-8f0d5ea04403c1581ef76560f668def14fddf8b9'
```