### PR TITLE
Allow editing and deletion of a tag

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,4 +1,10 @@
 class TagsController < ApplicationController
+  before_action :find_tag_by_params, only: [
+    :show,
+    :edit,
+    :update,
+    :destroy
+  ]
   respond_to :json, :html
 
   def index
@@ -17,18 +23,31 @@ class TagsController < ApplicationController
     respond_with @tag = Tag.create(tag_params)
   end
 
-  def show
-    @tag = find_tag_by_params
+  def destroy
+    redirect_to tags_url if @tag.destroy
   end
 
-  def edit
-    @tag = find_tag_by_params
+  def update
+    if @tag.update_attributes(tag_params)
+      flash[:notice] = "Tag was successfully updated."
+    else
+      flash[:error] = error_message(@tag)
+    end
+    respond_with @tag
   end
 
   private
 
+  def error_message(tag)
+    if tag.errors.messages.key?(:name)
+      "#{tag.name} #{tag.errors.messages[:name].first}."
+    else
+      "Tag could not be #{params[:action]}d."
+    end
+  end
+
   def find_tag_by_params
-    Tag.friendly.find(params[:id])
+    @tag = Tag.friendly.find(params[:id])
   end
 
   def tag_params

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -20,7 +20,13 @@ class TagsController < ApplicationController
   end
 
   def create
-    respond_with @tag = Tag.create(tag_params)
+    @tag = Tag.new(tag_params)
+    if @tag.save
+      flash[:notice] = "Tag was successfully created."
+    else
+      flash[:error] = error_message(@tag)
+    end
+    respond_with @tag
   end
 
   def destroy
@@ -39,8 +45,10 @@ class TagsController < ApplicationController
   private
 
   def error_message(tag)
-    if tag.errors.messages.key?(:name)
-      "#{tag.name} #{tag.errors.messages[:name].first}."
+    if tag.errors.messages.key?(:friendly_id)
+      "#{tag.name} is a reserved word."
+    elsif tag.errors.messages.key?(:name)
+      "#{tag.name.presence || :name.to_s.titleize} #{tag.errors.messages[:name].first}."
     else
       "Tag could not be #{params[:action]}d."
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,7 +4,7 @@ class Tag < ApplicationRecord
   has_many :articles_tags, dependent: :destroy
   has_many :articles, through: :articles_tags, counter_cache: :articles_count
 
-  validates :name, uniqueness: { case_sensitive: false }
+  validates :name, uniqueness: { case_sensitive: false }, presence: true
 
   friendly_id :name
 

--- a/app/views/tags/_form.html.haml
+++ b/app/views/tags/_form.html.haml
@@ -1,9 +1,8 @@
+%p.label.mbxs= label_text
 = simple_form_for @tag do | f |
 
   %fieldset.form-field.mbl
 
-    = f.label :name do
-      %span.form-label.label Tag Name
-      = f.input_field :name, class: 'form-input'
+    = f.input_field :name, class: 'form-input', placeholder: 'Enter a Tag Name'
 
   = f.button :submit, class: 'btn btn--a btn--l'

--- a/app/views/tags/edit.html.haml
+++ b/app/views/tags/edit.html.haml
@@ -1,2 +1,4 @@
-%h1 Tags#edit
-%p Find me in app/views/tags/edit.html.haml
+%section.row
+  .cell.well.well--l
+
+    = render partial: 'form', locals: { label_text: 'Edit a Tag'  }

--- a/app/views/tags/new.html.haml
+++ b/app/views/tags/new.html.haml
@@ -1,7 +1,6 @@
 %section.row
   .cell.cell--s.well.well--l
 
-    %h1.mbm New Tag
-
     .form
-      = render 'form'
+      = render partial: 'form', locals: { label_text: 'Create a New Tag'  }
+

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -9,3 +9,11 @@
           - # TODO: Add Article fresh/stale/rotten signals
           %li.card.list-item.article
             = link_to article, article, class: 'article-title'
+
+    %ul.list.list--inline.list--inline--xs.mbm.mtm
+      %li.list-item
+        = link_to 'Edit', edit_tag_url( @tag ), class: 'btn btn--a',
+          data: { shortcut: 'e' }
+
+      %li.list-item
+        = link_to 'Delete', @tag, class: 'btn btn--b', data: { method: :delete, confirm: "Are you sure?" }

--- a/spec/features/creating_a_tag_spec.rb
+++ b/spec/features/creating_a_tag_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Creating an tag" do
+  let(:tag) { create(:tag) }
+  before { visit new_tag_path }
+
+  context "with valid parameters" do
+
+    before do
+      fill_in "tag_name", with: content
+      click_button "Create Tag"
+    end
+
+    context "and content" do
+      let(:content) { "This is a test" }
+
+      it "doesn't redirect to the new tag page" do
+        expect(current_path).to_not eq(new_tag_path)
+        expect(page).to have_content "Tag was successfully created."
+      end
+    end
+
+  end
+
+  context "with invalid parameters" do
+    before("and an existing keyword") do
+      create(:tag, name: "ABC")
+    end
+
+    before do
+      fill_in "tag_name", with: content
+      click_button "Create Tag"
+    end
+
+    context "and no content" do
+      let(:content) { "" }
+
+      it "renders the new tag page" do
+        expect(page).to have_content("Create a New Tag")
+        expect(page).to have_content("Name can't be blank.")
+      end
+    end
+    context "and a reserved keyword" do
+      let(:content) { "new" }
+
+      it "renders the new tag page" do
+        expect(page).to have_content("Create a New Tag")
+        expect(page).to have_content("new is a reserved word.")
+      end
+    end
+
+    context "and an existing keyword" do
+      let(:content) { "ABC" }
+
+      it "renders the new tag page" do
+        expect(page).to have_content("Create a New Tag")
+        expect(page).to have_content("ABC has already been taken.")
+      end
+    end
+  end
+end

--- a/spec/features/deleting_a_tag_spec.rb
+++ b/spec/features/deleting_a_tag_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe 'deleting an tag' do
+  let(:tag) { create(:tag) }
+
+  it "it should redirect to tags index" do
+    visit tag_path(tag)
+    click_link_or_button 'Delete'
+    expect(current_path).to eq(tags_path)
+  end
+
+end

--- a/spec/features/updating_a_tag_spec.rb
+++ b/spec/features/updating_a_tag_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "Updating a tag" do
+  let(:tag) { create(:tag) }
+
+  before { visit edit_tag_path(tag) }
+
+  context "with valid parameters" do
+    before do
+      fill_in "tag_name", with: content
+      click_button "Update Tag"
+    end
+
+    context "and content" do
+      let(:content) { "This is a test" }
+
+      it "doesn't redirect to the edit page" do
+        expect(current_path).to_not eq(edit_tag_path(tag))
+        expect(page).to have_content "Tag was successfully updated."
+      end
+    end
+
+  end
+
+  context "with invalid parameters" do
+    before("and an existing keyword") do
+      create(:tag, name: "ABC")
+    end
+
+    before do
+      fill_in "tag_name", with: content
+      click_button "Update Tag"
+    end
+
+    context "with no content" do
+      let(:content) { "" }
+
+      it "displays an error" do
+        expect(page).to have_content("Name can't be blank")
+      end
+    end
+
+    context "with existing tag" do
+      let(:content) { "ABC" }
+
+      it "displays an error" do
+        expect(page).to have_content("Edit a Tag")
+        expect(page).to have_content("ABC has already been taken.")
+      end
+    end
+
+    context "with a reserved keyword" do
+      let(:content) { "new" }
+
+      it "renders the new tag page" do
+        expect(page).to have_content("Edit a Tag")
+        expect(page).to have_content("new is a reserved word.")
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
- Current version does not allow editing or deletion of tags
- Added the ability to do so with similar flow that exists for articles

**Edit & delete buttons in the tag show page**
![image](https://cloud.githubusercontent.com/assets/892961/17274632/0233913c-571d-11e6-8bc6-880d6b1a20f7.png)

**Edit tag page**
![image](https://cloud.githubusercontent.com/assets/892961/17274630/e4e4432e-571c-11e6-94f5-88be5241ee6a.png)


