### PR TITLE
Fix Deploy to Heroku by making app.json valid JSON

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,7 @@
     },
     "GOOGLE_KEY": {
       "required": true
-    },
+    }
   },
   "buildpacks" : [
     {


### PR DESCRIPTION
JSON objects cannot have trailing commas, so the object was invalid as
written. This prevents the "Deploy to Heroku" button from working.
Removing this comma makes the `app.json` file pass validation and should
fix the "Deploy to Heroku" functionality.