### PR TITLE
Force HTTPS for GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 ruby ENV['CUSTOM_RUBY_VERSION'] || '2.3.1'
 
+# Force HTTPS for GitHub under bundler 1.x, which is the default for bundler 2.x
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
 gem 'rails', "5.0.0"
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
@@ -34,7 +37,7 @@ gem 'slack-notifier'
 gem 'friendly_id', github: "norman/friendly_id", branch: "master"
 gem 'dotenv-rails'
 gem 'redis', '~> 3.0'
-# platform-api fork is necessary to allow letsencrypt-rails-heroku to 
+# platform-api fork is necessary to allow letsencrypt-rails-heroku to
 # make Heroku API requests to upload the Let's Encrypt SSL certificates
 gem 'platform-api', github: 'jalada/platform-api', branch: 'master'
 gem 'letsencrypt-rails-heroku', group: 'production'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby ENV['CUSTOM_RUBY_VERSION'] || '2.3.1'
 
 # Force HTTPS for GitHub under bundler 1.x, which is the default for bundler 2.x
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'rails', "5.0.0"
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/Casecommons/pg_search.git
+  remote: https://github.com/Casecommons/pg_search
   revision: 19ebda28fcfe41fd809b5d7e41e36076a46f27ad
   specs:
     pg_search (1.0.6)
@@ -8,7 +8,7 @@ GIT
       arel
 
 GIT
-  remote: https://github.com/audionerd/draper.git
+  remote: https://github.com/audionerd/draper
   revision: e816e0e5876b76c648c0928f1c3f2aa2c7a3d1f2
   branch: rails5
   specs:
@@ -19,7 +19,7 @@ GIT
       request_store (~> 1.0)
 
 GIT
-  remote: https://github.com/jalada/platform-api.git
+  remote: https://github.com/jalada/platform-api
   revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
   branch: master
   specs:
@@ -27,7 +27,7 @@ GIT
       heroics (~> 0.0.17)
 
 GIT
-  remote: https://github.com/norman/friendly_id.git
+  remote: https://github.com/norman/friendly_id
   revision: aff0564584e84ffa505e6e278b65ca3c4ee5d698
   branch: master
   specs:
@@ -35,7 +35,7 @@ GIT
       activerecord (>= 4.0.0)
 
 GIT
-  remote: https://github.com/olivierlacan/simple_form.git
+  remote: https://github.com/olivierlacan/simple_form
   revision: 86ab4252ecad1956fa2ddeea2d62a1584dac10f6
   branch: rails-5-type-for-attribute
   specs:
@@ -44,7 +44,7 @@ GIT
       activemodel (> 4, < 5.1)
 
 GIT
-  remote: https://github.com/rails/activemodel-serializers-xml.git
+  remote: https://github.com/rails/activemodel-serializers-xml
   revision: 570ee7ed33d60e44ca1f3ccbec3d1fbf61d52cbf
   specs:
     activemodel-serializers-xml (1.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/Casecommons/pg_search.git
+  remote: https://github.com/Casecommons/pg_search.git
   revision: 19ebda28fcfe41fd809b5d7e41e36076a46f27ad
   specs:
     pg_search (1.0.6)
@@ -8,7 +8,7 @@ GIT
       arel
 
 GIT
-  remote: git://github.com/audionerd/draper.git
+  remote: https://github.com/audionerd/draper.git
   revision: e816e0e5876b76c648c0928f1c3f2aa2c7a3d1f2
   branch: rails5
   specs:
@@ -19,7 +19,7 @@ GIT
       request_store (~> 1.0)
 
 GIT
-  remote: git://github.com/jalada/platform-api.git
+  remote: https://github.com/jalada/platform-api.git
   revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
   branch: master
   specs:
@@ -27,15 +27,15 @@ GIT
       heroics (~> 0.0.17)
 
 GIT
-  remote: git://github.com/norman/friendly_id.git
-  revision: 8531cdce5737df541bc2dbf9c0fa3ee4824b6fc8
+  remote: https://github.com/norman/friendly_id.git
+  revision: aff0564584e84ffa505e6e278b65ca3c4ee5d698
   branch: master
   specs:
     friendly_id (5.2.0.beta.1)
       activerecord (>= 4.0.0)
 
 GIT
-  remote: git://github.com/olivierlacan/simple_form.git
+  remote: https://github.com/olivierlacan/simple_form.git
   revision: 86ab4252ecad1956fa2ddeea2d62a1584dac10f6
   branch: rails-5-type-for-attribute
   specs:
@@ -44,7 +44,7 @@ GIT
       activemodel (> 4, < 5.1)
 
 GIT
-  remote: git://github.com/rails/activemodel-serializers-xml.git
+  remote: https://github.com/rails/activemodel-serializers-xml.git
   revision: 570ee7ed33d60e44ca1f3ccbec3d1fbf61d52cbf
   specs:
     activemodel-serializers-xml (1.0.1)


### PR DESCRIPTION
Hi @olivierlacan, just a small contrib to avoid those warnings on latest bundler:

> The git source `git://github.com/olivierlacan/simple_form.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
