### PR TITLE
Split Archived Articles in Tag Listing

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -19,6 +19,8 @@ class TagsController < ApplicationController
 
   def show
     @tag = find_tag_by_params
+    @current_articles = @tag.articles.merge(Article.current).decorate
+    @archived_articles = @tag.articles.merge(Article.archived)
   end
 
   def edit

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -3,9 +3,20 @@
 
     %h1.mbs= @tag
 
-    - if @tag.articles.any?
+    - if @current_articles.any?
       %ul.list.list--xs
-        - @tag.articles.each do |article|
-          - # TODO: Add Article fresh/stale/rotten signals
+        - @current_articles.each do |article|
+          %li.card.list-item.article.has-signal
+            = article.signal
+            = link_to article, article, class: 'article-title'
+
+    - if @archived_articles.any?
+      - if @current_articles.any?
+        %h3.mtm Archived Articles
+      - else
+        %h3 Archived Articles
+
+      %ul.list.list--xs
+        - @archived_articles.each do |article|
           %li.card.list-item.article
             = link_to article, article, class: 'article-title'


### PR DESCRIPTION
These changes only decorate the current (unarchived) articles, lest we start coloring and sorting irrelevant information. A front-end person may want to take a look and modify appropriately.

As always, open to feedback.