### PR TITLE
Add OpenSearch specs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ ORIENTATION_FAVICON=default_favicon.png
 DEFAULT_FROM_NAME=Orientation
 DEFAULT_FROM_EMAIL=notifications@orientation.io
 
+# Sets the app name, which is used in the OpenSearch description. Change this to
+# something more representative of your usage. E.g. "Company Inc. Wiki"
+APP_NAME=Orientation
+
 # ============================ Rails configuration =========================== #
 SECRET_KEY_BASE=
 DATABASE_NAME=orientation_development

--- a/app/controllers/open_search/descriptions_controller.rb
+++ b/app/controllers/open_search/descriptions_controller.rb
@@ -1,0 +1,9 @@
+module OpenSearch
+  class DescriptionsController < ApplicationController
+    respond_to :osd_xml
+    # Serves the OpenSearch Description document so that you can use the omnibox
+    # and similar to search on Orientation.
+    def show
+    end
+  end
+end

--- a/app/helpers/open_search/descriptions_helper.rb
+++ b/app/helpers/open_search/descriptions_helper.rb
@@ -1,0 +1,14 @@
+module OpenSearch
+  module DescriptionsHelper
+    def open_search_description_link_tag
+      content_tag(
+        :link,
+        nil,
+        rel: 'search',
+        type: 'application/opensearchdescription+xml',
+        title: ENV.fetch('APP_NAME', 'Orientation'),
+        href: open_search_description_path
+      )
+    end
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,6 @@
 !!! 5
 %html{ lang: 'en' }
-  %head
+  %head{ profile: 'http://a9.com/-/spec/opensearch/1.1/' }
 
     %meta{ charset: 'utf-8' }
     %meta{ content: 'IE=edge,chrome=1', 'http-equiv' => 'X-UA-Compatible' }
@@ -12,6 +12,7 @@
     = favicon_link_tag ENV['ORIENTATION_FAVICON']
     = csrf_meta_tags
     = action_cable_meta_tag
+    = open_search_description_link_tag
 
   %body{ class: body_class }
 

--- a/app/views/open_search/descriptions/show.osd_xml.builder
+++ b/app/views/open_search/descriptions/show.osd_xml.builder
@@ -1,0 +1,24 @@
+xml.instruct!
+xml.OpenSearchDescription xmlns: 'http://a9.com/-/spec/opensearch/1.1/', 'xmlns:moz': 'http://www.mozilla.org/2006/browser/search/', 'xmlns:suggestions': 'http://www.opensearch.org/specifications/opensearch/extensions/suggestions/1.1' do
+  xml.AdultContent false
+  xml.Description "Search on #{ENV.fetch('APP_NAME', 'Orientation')}"
+  if ENV['ORIENTATION_FAVICON'].present?
+    xml.Image ENV['ORIENTATION_FAVICON'], width: 16, height: 16, type: 'image/x-icon'
+  end
+  if ENV['ORIENTATION_LOGO'].present?
+    xml.Image ENV['ORIENTATION_LOGO'], width: 64, height: 64, type: 'image/png'
+  end
+  xml.InputEncoding 'UTF-8'
+  xml.Language 'en-US'
+  xml.Language '*'
+  xml.LongName "#{ENV.fetch('APP_NAME', 'Orientation')} Search"
+  xml.OutputEncoding 'UTF-8'
+  xml.Query role: 'example', searchTerms: 'john smith'
+  xml.ShortName ENV.fetch('APP_NAME', 'Orientation')
+  xml.SyndicationRight 'limited'
+  xml.tag! 'moz:SearchForm', articles_url
+  # rels: results (default), suggestions, self, collection
+  # parameters: searchTerms (required), count, startIndex, startPage, language, inputEncoding, outputEncoding
+  xml.Url type: 'application/opensearchdescription+xml', rel: 'self', template: open_search_description_url
+  xml.Url type: 'text/html', template: "#{articles_url}?search={searchTerms}&utm_source=opensearch&utm_medium=search&utm_campaign=opensearch"
+end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register 'application/opensearchdescription+xml', :osd_xml

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,11 @@ Rails.application.routes.draw do
   resources :subscriptions, only: :index
   resources :endorsements, only: :index
 
+  get 'opensearchdescription.xml' => 'open_search/descriptions#show',
+    format: false,
+    defaults: { format: :osd_xml },
+    as: :open_search_description
+
   # this has to be the last route because we're catching slugs at the root path
   resources :articles, path: "", only: :show
 

--- a/spec/controllers/open_search/descriptions_controller_spec.rb
+++ b/spec/controllers/open_search/descriptions_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe OpenSearch::DescriptionsController, type: :controller do
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show, format: :osd_xml
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
We use Orientation [at Doximity](https://engineering.doximity.com/) for our internal wiki and I wanted to make searching the wiki a little bit easier for our quarterly Hack Day.

This adds OpenSearch specs to Orientation so when you're in Chrome you can type "orien..." and it will suggest "Press [tab] to search Orientation". After hitting tab, typing a search query and hitting enter will direct you to `/articles/search?search=...`.

Here's some screenshots from Chrome locally:

Suggestion:
<img width="588" alt="screenshot 2017-01-30 15 02 02" src="https://cloud.githubusercontent.com/assets/27628/22439319/288fed7e-e6fd-11e6-9bc2-b014a93b872a.png">

Tabbed:
<img width="589" alt="screenshot 2017-01-30 15 02 13" src="https://cloud.githubusercontent.com/assets/27628/22439321/298c99fc-e6fd-11e6-9019-db52d2d6c0ee.png">

Hit enter:
<img width="676" alt="screenshot 2017-01-30 15 02 23" src="https://cloud.githubusercontent.com/assets/27628/22439322/2b64d8ac-e6fd-11e6-995b-605d598d6f36.png">

You can control the text in the search box via the `$APP_NAME` environment variable. E.g. we set ours to "Doximity Wiki".