### PR TITLE
WIP Add config.autoload_paths << Rails.root.join('lib') in config/application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,6 @@ module Orientation
     #   Rails.configuration.orientation["transactional_mailer"]
     #
     config.orientation = config_for(:orientation)
+    config.autoload_paths << Rails.root.join('lib')
   end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/140893151
Fix uninitialized constant ArticleMailer::HTMLDiffTool error.

According to the Rails 5 guides: Lib was in the list years ago, but no longer is. so it is added. 