### PR TITLE
Replace Pygments.rb with Rouge

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,4 @@
 brew "postgresql" unless system "which psql"
-brew "python" unless system "which python"
 brew "redis" unless system "which redis"
 brew "node@8" unless system "which node"
 brew "yarn" unless system "which yarn"

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'sidekiq-unique-jobs'
 gem 'simple_form'
 
 # Server-side syntax highlighting
-gem 'pygments.rb'
+gem 'rouge'
 
 # Markdown parsing and rendering
 gem 'redcarpet', '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,8 +221,6 @@ GEM
       slop (~> 3.0)
     public_suffix (3.0.3)
     puma (3.12.0)
-    pygments.rb (1.1.1)
-      multi_json (>= 1.0.0)
     rack (2.0.6)
     rack-protection (2.0.4)
       rack
@@ -269,6 +267,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rouge (3.3.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.1)
@@ -391,13 +390,13 @@ DEPENDENCIES
   pry-rails
   pry-remote
   puma (~> 3.0)
-  pygments.rb
   rack-timeout
   rails (~> 5.2.2)
   rails_12factor
   redcarpet (~> 3.4.0)
   redis (~> 3.0)
   responders (~> 2.0)
+  rouge
   rspec-rails
   sass-rails
   sidekiq

--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ machine with the `bin/system` command using [Homebrew](https://brew.sh/).
 
 - Ruby 2.3 to 2.6
 - PostgreSQL 9.3+ (with JSON support, and fuzzystrmatch & pg_trgm extensions)
-- Python 2.7 (for Pygments)
 - Node.js 8.12.0 (for yarn)
 - yarn
 
-Both Node and Python are available on Heroku if you decide to deploy there,
-which means there should not be any issues when deploying or running Orientation
+Node is available on Heroku if you decide to deploy there, which means
+there should not be any issues when deploying or running Orientation
 there.
 
 ### Services

--- a/app/assets/stylesheets/structures/_markdown.sass
+++ b/app/assets/stylesheets/structures/_markdown.sass
@@ -120,7 +120,6 @@
   // Code
 
   code
-    background: darken($c-background, 3%)
     border-radius: $b-borderRadius
     display: inline-block
     padding-left: $b-space-xs

--- a/app/assets/stylesheets/vendor/_highlight.scss
+++ b/app/assets/stylesheets/vendor/_highlight.scss
@@ -16,67 +16,212 @@
   }
 }
 
-.highlight .hll { background-color: #d6d6d6 }
-.highlight .c { color: #8e908c } /* Comment */
-.highlight .err { color: #c82829 } /* Error */
-.highlight .k { color: #8959a8 } /* Keyword */
-.highlight .l { color: #f5871f } /* Literal */
-.highlight .n { color: #4d4d4c } /* Name */
-.highlight .o { color: #3e999f } /* Operator */
-.highlight .p { color: #4d4d4c } /* Punctuation */
-.highlight .cm { color: #8e908c } /* Comment.Multiline */
-.highlight .cp { color: #8e908c } /* Comment.Preproc */
-.highlight .c1 { color: #8e908c } /* Comment.Single */
-.highlight .cs { color: #8e908c } /* Comment.Special */
-.highlight .gd { color: #c82829 } /* Generic.Deleted */
-.highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gh { color: #4d4d4c; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #718c00 } /* Generic.Inserted */
-.highlight .gp { color: #8e908c; font-weight: bold } /* Generic.Prompt */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #3e999f; font-weight: bold } /* Generic.Subheading */
-.highlight .kc { color: #8959a8 } /* Keyword.Constant */
-.highlight .kd { color: #8959a8 } /* Keyword.Declaration */
-.highlight .kn { color: #3e999f } /* Keyword.Namespace */
-.highlight .kp { color: #8959a8 } /* Keyword.Pseudo */
-.highlight .kr { color: #8959a8 } /* Keyword.Reserved */
-.highlight .kt { color: #eab700 } /* Keyword.Type */
-.highlight .ld { color: #718c00 } /* Literal.Date */
-.highlight .m { color: #f5871f } /* Literal.Number */
-.highlight .s { color: #718c00 } /* Literal.String */
-.highlight .na { color: #4271ae } /* Name.Attribute */
-.highlight .nb { color: #4d4d4c } /* Name.Builtin */
-.highlight .nc { color: #eab700 } /* Name.Class */
-.highlight .no { color: #c82829 } /* Name.Constant */
-.highlight .nd { color: #3e999f } /* Name.Decorator */
-.highlight .ni { color: #4d4d4c } /* Name.Entity */
-.highlight .ne { color: #c82829 } /* Name.Exception */
-.highlight .nf { color: #4271ae } /* Name.Function */
-.highlight .nl { color: #4d4d4c } /* Name.Label */
-.highlight .nn { color: #eab700 } /* Name.Namespace */
-.highlight .nx { color: #4271ae } /* Name.Other */
-.highlight .py { color: #4d4d4c } /* Name.Property */
-.highlight .nt { color: #3e999f } /* Name.Tag */
-.highlight .nv { color: #c82829 } /* Name.Variable */
-.highlight .ow { color: #3e999f } /* Operator.Word */
-.highlight .w { color: #4d4d4c } /* Text.Whitespace */
-.highlight .mf { color: #f5871f } /* Literal.Number.Float */
-.highlight .mh { color: #f5871f } /* Literal.Number.Hex */
-.highlight .mi { color: #f5871f } /* Literal.Number.Integer */
-.highlight .mo { color: #f5871f } /* Literal.Number.Oct */
-.highlight .sb { color: #718c00 } /* Literal.String.Backtick */
-.highlight .sc { color: #4d4d4c } /* Literal.String.Char */
-.highlight .sd { color: #8e908c } /* Literal.String.Doc */
-.highlight .s2 { color: #718c00 } /* Literal.String.Double */
-.highlight .se { color: #f5871f } /* Literal.String.Escape */
-.highlight .sh { color: #718c00 } /* Literal.String.Heredoc */
-.highlight .si { color: #f5871f } /* Literal.String.Interpol */
-.highlight .sx { color: #718c00 } /* Literal.String.Other */
-.highlight .sr { color: #718c00 } /* Literal.String.Regex */
-.highlight .s1 { color: #718c00 } /* Literal.String.Single */
-.highlight .ss { color: #718c00 } /* Literal.String.Symbol */
-.highlight .bp { color: #4d4d4c } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #c82829 } /* Name.Variable.Class */
-.highlight .vg { color: #c82829 } /* Name.Variable.Global */
-.highlight .vi { color: #c82829 } /* Name.Variable.Instance */
-.highlight .il { color: #f5871f } /* Literal.Number.Integer.Long */
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight .cm {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cp {
+  color: #999999;
+  font-weight: bold;
+}
+.highlight .c1 {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .c, .highlight .cd {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+.highlight .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+.highlight .ge {
+  color: #000000;
+  font-style: italic;
+}
+.highlight .gr {
+  color: #aa0000;
+}
+.highlight .gh {
+  color: #999999;
+}
+.highlight .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+.highlight .go {
+  color: #888888;
+}
+.highlight .gp {
+  color: #555555;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .gu {
+  color: #aaaaaa;
+}
+.highlight .gt {
+  color: #aa0000;
+}
+.highlight .kc {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kd {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kn {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kp {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kr {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kt {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .k, .highlight .kv {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .mf {
+  color: #009999;
+}
+.highlight .mh {
+  color: #009999;
+}
+.highlight .il {
+  color: #009999;
+}
+.highlight .mi {
+  color: #009999;
+}
+.highlight .mo {
+  color: #009999;
+}
+.highlight .m, .highlight .mb, .highlight .mx {
+  color: #009999;
+}
+.highlight .sb {
+  color: #d14;
+}
+.highlight .sc {
+  color: #d14;
+}
+.highlight .sd {
+  color: #d14;
+}
+.highlight .s2 {
+  color: #d14;
+}
+.highlight .se {
+  color: #d14;
+}
+.highlight .sh {
+  color: #d14;
+}
+.highlight .si {
+  color: #d14;
+}
+.highlight .sx {
+  color: #d14;
+}
+.highlight .sr {
+  color: #009926;
+}
+.highlight .s1 {
+  color: #d14;
+}
+.highlight .ss {
+  color: #990073;
+}
+.highlight .s {
+  color: #d14;
+}
+.highlight .na {
+  color: #008080;
+}
+.highlight .bp {
+  color: #999999;
+}
+.highlight .nb {
+  color: #0086B3;
+}
+.highlight .nc {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .no {
+  color: #008080;
+}
+.highlight .nd {
+  color: #3c5d5d;
+  font-weight: bold;
+}
+.highlight .ni {
+  color: #800080;
+}
+.highlight .ne {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nf {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nl {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nn {
+  color: #555555;
+}
+.highlight .nt {
+  color: #000080;
+}
+.highlight .vc {
+  color: #008080;
+}
+.highlight .vg {
+  color: #008080;
+}
+.highlight .vi {
+  color: #008080;
+}
+.highlight .nv {
+  color: #008080;
+}
+.highlight .ow {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .o {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .w {
+  color: #bbbbbb;
+}
+.highlight {
+  background-color: #f8f8f8;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def markdown(text)
-    renderer = HtmlWithPygments.new(hard_wrap: true, escape_html: true)
+    renderer = HtmlWithRouge.new(hard_wrap: true, escape_html: true)
     Redcarpet::Markdown.new(renderer, markdown_options.merge(footnotes: true)).render(text).html_safe
   end
 

--- a/app/helpers/html_with_rouge.rb
+++ b/app/helpers/html_with_rouge.rb
@@ -1,4 +1,10 @@
-class HtmlWithPygments < Redcarpet::Render::HTML
+require 'redcarpet'
+require 'rouge'
+require 'rouge/plugins/redcarpet'
+
+class HtmlWithRouge < Redcarpet::Render::HTML
+  include Rouge::Plugins::Redcarpet
+
   def header(title, level)
     permalink = title.parameterize.downcase
     %(
@@ -10,11 +16,9 @@ class HtmlWithPygments < Redcarpet::Render::HTML
   end
 
   def block_code(code, language)
-    safe_language = Pygments::Lexer.find_by_alias(language) ? language : nil
-
     sha = Digest::SHA1.hexdigest(code)
-    Rails.cache.fetch ["code", safe_language, sha].join('-') do
-      Pygments.highlight(code, lexer: safe_language)
+    Rails.cache.fetch ["code", language, sha].join("-") do
+      super
     end
   end
 


### PR DESCRIPTION
Long time coming but now that Pygments.rb is barely maintained, that it depends
on a very old version of Python (2.7) and complicates the installation process
for Orientation, it was about time to switch to the most excellent all-Ruby
alternative: http://rouge.jneen.net

I can't believe how easy it was to switch over. Rouge even aliases `shell`
to `bash` and vice-versa which makes the lexer hack I had with Pygments
unnecessary (it would blow up on languages it didn't know).

Rouge on the contrary just doesn't do any highlighting for any language passed
in the Markdown fenced codeblocks that it can't recognize (triple backticks
followed by the language name in lowercase)

What a relief!

Oh, and I took the opportunity to refresh the CSS we're using to display
highlighted code to switch to the GitHub styles which are quite appropriate for
the current Orientation theme.