### PR TITLE
get_process_mem bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       sassc (>= 1.11)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
-    get_process_mem (0.2.2)
+    get_process_mem (0.2.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)


### PR DESCRIPTION
Fixes this annoying deprecation warning:

```
get_process_mem.rb:10: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```