### PR TITLE
Improve Markdown guide in new article form

### DIFF
--- a/app/assets/javascripts/components/accordion.coffee
+++ b/app/assets/javascripts/components/accordion.coffee
@@ -18,10 +18,8 @@
     $content : $( '.js-accordion-content' )
   , options
 
-  settings.$content.hide()
-
   settings.$button.on 'click', ( event ) ->
-    $(@).closest( settings.$element ).find( settings.$content ).slideToggle()
+    $(@).closest( settings.$element ).find( settings.$content ).slideToggle(100)
 
 # -------------------------------------
 #   Usage

--- a/app/assets/stylesheets/components/_accordion.sass
+++ b/app/assets/stylesheets/components/_accordion.sass
@@ -1,0 +1,17 @@
+// *************************************
+//
+//   Accordion
+//   -> Unfolding interface elements
+//
+// -------------------------------------
+//   Template (Haml)
+// -------------------------------------
+//
+// .js-accordion
+// .js-accordion-button
+//   / ...
+//
+// *************************************
+
+.js-accordion-button
+  cursor: pointer

--- a/app/views/articles/_markdown_guide.haml
+++ b/app/views/articles/_markdown_guide.haml
@@ -35,14 +35,14 @@
         .split-cell
           = render partial: 'shared/icon', locals: { icon: 'caret-down', middle: true, klass: 'tcs tsxs' }
       .js-accordion-content
-        %textarea.form-input.form-textarea.form-textarea--pre.mbs.js-selectText{ readonly: true, rows: 3 }
-          \- This is the first item in an unordered list
-          \- This is the second item in an unordered list
-          \- This is the third item in an unordered list
-        %textarea.form-input.form-textarea.form-textarea--pre.mbf.js-selectText{ readonly: true, rows: 3 }
-          \1. This is the first item in an ordered list
-          \2. This is the second item in an ordered list
-          \3. This is the third item in an ordered list
+        %textarea.form-input.form-textarea.mbs.js-selectText{ readonly: true, rows: 3 }
+          \- first unordered list item
+          \- second unordered list item
+          \- third unordered list item
+        %textarea.form-input.form-textarea.mbf.js-selectText{ readonly: true, rows: 3 }
+          \1. first ordered list item
+          \2. second ordered list item
+          \3. third ordered list item
 
 .card-section.pbs.pts
   .form.mbf
@@ -54,9 +54,14 @@
           = render partial: 'shared/icon', locals: { icon: 'caret-down', middle: true, klass: 'tcs tsxs' }
       .js-accordion-content
         %input.form-input.mbs.js-selectText{ type: 'text', readonly: true, value: '`This is inline code`' }
-        %textarea.form-input.form-textarea.form-textarea--pre.js-selectText{ readonly: true, rows: 3 }
-          \```
-          This is a code block
+        %textarea.form-input.form-textarea.js-selectText{ readonly: true, rows: 5 }
+          \```ruby
+          \# This is a code block which
+          \# can be syntax highlighted
+          \# if you specify the language.
+          user = User.new
+          user.save
+          \# => User
           \```
 
 .card-section.pbs.pts


### PR DESCRIPTION
- [x] don't collapse each section by default, it just adds busy work for writers
- [x] speed up collapsing speed if needed
- [x] fix broken formatting (one line display) due to the preformatted styling
- [x] display an affordance to show that the section can be collapsed
- [x] shorten list examples for brevity
- [x] improve code block example and show language-specific highlighting can
be used