### PR TITLE
Fix OmniAuth security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'redcarpet', '~> 3.4.0'
 # OAuth integration
 gem 'omniauth'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
 
 # Full-text search with PostgreSQL
 gem 'pg_search'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     pg (1.1.4)
     pg_search (2.3.0)
       activerecord (>= 4.2)
@@ -386,6 +389,7 @@ DEPENDENCIES
   mandrill_mailer
   omniauth
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg
   pg_search
   pry-byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
 
       # In the development environment, your current_user will be the
       # first User in the database or a dummy one created below.
-      if Rails.env.development? || Rails.env.test? || demo_app?
+      if false # Rails.env.development? || Rails.env.test? || demo_app?
         user = User.first_or_create!(name: "Orientation", email: "about@orientation.io")
         session[:user_id] = user.id
       else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,6 @@
 class SessionsController < ApplicationController
   def new
-    origin = { origin: session.delete(:return_to) }.to_query
-    redirect_to("/auth/google_oauth2?#{origin}")
+    @origin = { origin: session.delete(:return_to) }.to_query
   end
 
   def create

--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -1,0 +1,1 @@
+= link_to 'Sign in with Google', "/auth/google_oauth2?#{@origin}", method: :post


### PR DESCRIPTION
This will eventually mean adding non-seamless step to authenticate to Google
which makes a lot of sense (it requires a post request from a link) in general
so people aren't redirected to an OAuth provider without warning.

I'll have to design a new page for that and it will actually make customizing
the OAuth provider that much easier.